### PR TITLE
Fix best autonomous community metric to use CSV data

### DIFF
--- a/src/pages/Investment/index.tsx
+++ b/src/pages/Investment/index.tsx
@@ -810,18 +810,13 @@ const Investment: React.FC<InvestmentProps> = ({ language }) => {
                             ? bestRegion["Comunidad Limpio"] 
                             : bestRegion["Comunidad en Inglés"];
                           
-                          // Re-calcular el valor por si hay comas o puntos mezclados
-                          let value = 0;
-                          try {
-                            // Buscar el valor específico en el array de datos
-                            const val = allRegionData
-                              .filter(item => item["Comunidad Limpio"] === bestRegion["Comunidad Limpio"])
-                              .map(item => [item["Sector Nombre"], item["% PIB I+D"]])
-                              .find(([key]) => key === "% PIB I+D")?.[1] || '0';
-                            value = parseFloat(String(val).replace(',', '.'));
-                          } catch {
-                            // En caso de error, usar valor por defecto
-                        }
+                            // Obtener el valor del % del PIB en I+D para la región seleccionada
+                            let value = 0;
+                            try {
+                              value = parseFloat(bestRegion["% PIB I+D"].replace(',', '.'));
+                            } catch {
+                              // En caso de error, usar el valor por defecto
+                            }
                         
                         return (
                           <div>


### PR DESCRIPTION
## Summary
- compute top Spanish autonomous community metric using parsed CSV values rather than hardcoded 0

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx eslint src/pages/Investment/index.tsx --format json`


------
https://chatgpt.com/codex/tasks/task_e_6899365d449c83289523705164115194