### PR TITLE
Use local Spanish flag for investment metric

### DIFF
--- a/public/es.svg
+++ b/public/es.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#c60b1e"/>
+  <rect y="0.5" width="3" height="1" fill="#ffc400"/>
+</svg>

--- a/src/pages/Investment/index.tsx
+++ b/src/pages/Investment/index.tsx
@@ -633,12 +633,12 @@ const Investment: React.FC<InvestmentProps> = ({ language }) => {
                 <div className="flex items-start">
                   <div className="flex-shrink-0 mr-3">
                     <div className="p-2 sm:p-3 bg-red-50 rounded-lg flex items-center justify-center">
-                      <img 
-                        src="https://flagcdn.com/es.svg" 
-                        alt="Bandera de España" 
+                      <img
+                        src="/es.svg"
+                        alt="Bandera de España"
                         className="w-6 h-4 sm:w-8 sm:h-6 object-cover rounded border border-gray-300 shadow-sm"
-                        style={{ 
-                          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1)' 
+                        style={{
+                          boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1)'
                         }}
                         onError={(e) => {
                           // Fallback al icono SVG si la imagen no carga


### PR DESCRIPTION
## Summary
- serve Spain flag from local SVG to avoid slow external load

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6899bcc218288328871ae2f8735feb1d