### PR TITLE
refactor: centralize territory mapping

### DIFF
--- a/src/components/CommunityDistribution.tsx
+++ b/src/components/CommunityDistribution.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { Calendar, ChevronDown } from 'lucide-react';
 import Papa from 'papaparse';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { communityFlags, communityNameMapping } from '../utils/spanishCommunitiesUtils';
 
 // Definición de los sectores de I+D
 const rdSectors = [
@@ -140,9 +140,9 @@ const Flag: React.FC<FlagProps> = ({ code, width = 24, height = 18, className = 
   
   // Búsqueda de banderas en el JSON
   const esFlag = "/logos/spain.svg";
-  const canaryFlag = autonomous_communities_flags.find(community => community.code === 'CAN');
-  const communityFlag = code === 'community' && communityCode ? 
-    autonomous_communities_flags.find(community => community.code === communityCode) : null;
+  const canaryFlag = communityFlags.find(community => community.code === 'CAN');
+  const communityFlag = code === 'community' && communityCode ?
+    communityFlags.find(community => community.code === communityCode) : null;
   
   switch(code) {
     case 'es':
@@ -197,63 +197,6 @@ interface CustomTooltipProps {
 }
 
 // Tabla de mapeo entre nombres de comunidades en el CSV y nombres en español/inglés
-const communityNameMapping: { [key: string]: { es: string, en: string } } = {
-  'Andalucía': { es: 'Andalucía', en: 'Andalusia' },
-  'Andalucia': { es: 'Andalucía', en: 'Andalusia' },
-  'Aragón': { es: 'Aragón', en: 'Aragon' },
-  'Aragon': { es: 'Aragón', en: 'Aragon' },
-  'Principado de Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Illes Balears / Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Illes Balears': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Balearic Islands': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Islas Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Canary Islands': { es: 'Canarias', en: 'Canary Islands' },
-  'Cantabria': { es: 'Cantabria', en: 'Cantabria' },
-  'Castilla - La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-la Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castillalamancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla y León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla y Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Cataluña': { es: 'Cataluña', en: 'Catalonia' },
-  'Cataluna': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalunya': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalonia': { es: 'Cataluña', en: 'Catalonia' },
-  'Comunidad Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'C. Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencia': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencian Community': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Extremadura': { es: 'Extremadura', en: 'Extremadura' },
-  'Galicia': { es: 'Galicia', en: 'Galicia' },
-  'La Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Comunidad de Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Región de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Region de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Comunidad Foral de Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarre': { es: 'Navarra', en: 'Navarre' },
-  'País Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Pais Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Euskadi': { es: 'País Vasco', en: 'Basque Country' },
-  'Basque Country': { es: 'País Vasco', en: 'Basque Country' },
-  'Ciudad Autónoma de Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ciudad Autónoma de Melilla': { es: 'Melilla', en: 'Melilla' },
-  'Melilla': { es: 'Melilla', en: 'Melilla' }
-};
 
 const CommunityDistribution: React.FC<CommunityDistributionProps> = ({ language }) => {
   const [selectedYear, setSelectedYear] = useState<string>('2023');
@@ -264,7 +207,7 @@ const CommunityDistribution: React.FC<CommunityDistributionProps> = ({ language 
   const [selectedCommunity, setSelectedCommunity] = useState<CommunityOption>({
     name: language === 'es' ? 'Madrid' : 'Madrid',
     code: 'MAD',
-    flag: autonomous_communities_flags.find(f => f.code === 'MAD')?.flag || ''
+    flag: communityFlags.find(f => f.code === 'MAD')?.flag || ''
   });
   const [availableCommunities, setAvailableCommunities] = useState<CommunityOption[]>([]);
   const [ccaaData, setCcaaData] = useState<GastoIDComunidadesData[]>([]);
@@ -463,7 +406,7 @@ const CommunityDistribution: React.FC<CommunityDistributionProps> = ({ language 
           }
         }
 
-        const communityFlag = autonomous_communities_flags.find(flag =>
+        const communityFlag = communityFlags.find(flag =>
           normalizeText(flag.community).includes(normalizeText(communityName)) ||
           normalizeText(communityName).includes(normalizeText(flag.community))
         );

--- a/src/components/CommunityRDComparisonChart.tsx
+++ b/src/components/CommunityRDComparisonChart.tsx
@@ -8,11 +8,11 @@ import {
   ResponsiveContainer,
   Customized
 } from 'recharts';
-import { 
+import {
   ChevronDown
 } from 'lucide-react';
 import country_flags from '../logos/country_flags.json';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { communityFlags, communityNameMapping } from '../utils/spanishCommunitiesUtils';
 
 // Interfaz para los datos de PIB y gasto en I+D
 interface GDPConsolidadoData {
@@ -98,63 +98,6 @@ interface AxisScale {
 }
 
 // Tabla de mapeo entre nombres de comunidades en el CSV y nombres en español/inglés
-const communityNameMapping: { [key: string]: { es: string, en: string } } = {
-  'Andalucía': { es: 'Andalucía', en: 'Andalusia' },
-  'Andalucia': { es: 'Andalucía', en: 'Andalusia' },
-  'Aragón': { es: 'Aragón', en: 'Aragon' },
-  'Aragon': { es: 'Aragón', en: 'Aragon' },
-  'Principado de Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Illes Balears / Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Illes Balears': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Balearic Islands': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Islas Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Canary Islands': { es: 'Canarias', en: 'Canary Islands' },
-  'Cantabria': { es: 'Cantabria', en: 'Cantabria' },
-  'Castilla - La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-la Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castillalamancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla y León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla y Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Cataluña': { es: 'Cataluña', en: 'Catalonia' },
-  'Cataluna': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalunya': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalonia': { es: 'Cataluña', en: 'Catalonia' },
-  'Comunidad Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'C. Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencia': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencian Community': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Extremadura': { es: 'Extremadura', en: 'Extremadura' },
-  'Galicia': { es: 'Galicia', en: 'Galicia' },
-  'La Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Comunidad de Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Región de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Region de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Comunidad Foral de Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarre': { es: 'Navarra', en: 'Navarre' },
-  'País Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Pais Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Euskadi': { es: 'País Vasco', en: 'Basque Country' },
-  'Basque Country': { es: 'País Vasco', en: 'Basque Country' },
-  'Ciudad Autónoma de Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ciudad Autónoma de Melilla': { es: 'Melilla', en: 'Melilla' },
-  'Melilla': { es: 'Melilla', en: 'Melilla' }
-};
 
 // Parámetros para las banderas
 const FLAG_SIZE = 20;
@@ -275,7 +218,7 @@ const CommunityRDComparisonChart: React.FC<CommunityRDComparisonChartProps> = ({
         }
         
         // Buscar la comunidad en el objeto de banderas
-        const flag = autonomous_communities_flags.find(f => 
+        const flag = communityFlags.find(f =>
           normalizeText(f.community) === normalizeText(communityName) || 
           f.community.includes(originalName.replace(/\(ES\d+\)\s/, ''))
         );
@@ -617,10 +560,10 @@ const CommunityRDComparisonChart: React.FC<CommunityRDComparisonChartProps> = ({
       const spainFlag = country_flags.find(flag => flag.iso3 === 'ESP');
       flagUrl = spainFlag?.flag || '';
     } else if (type === 'canary') {
-      const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+      const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
       flagUrl = canaryFlag?.flag || '';
     } else if (type === 'community' && code) {
-      const communityFlag = autonomous_communities_flags.find(flag => flag.code === code);
+      const communityFlag = communityFlags.find(flag => flag.code === code);
       flagUrl = communityFlag?.flag || '';
     }
     
@@ -671,10 +614,10 @@ const CommunityRDComparisonChart: React.FC<CommunityRDComparisonChartProps> = ({
         const spainFlag = country_flags.find(flag => flag.iso3 === 'ESP');
         return spainFlag?.flag || '';
       } else if (type === 'canary') {
-        const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+        const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
         return canaryFlag?.flag || '';
       } else if (type === 'community' && code) {
-        const communityFlag = autonomous_communities_flags.find(flag => flag.code === code);
+        const communityFlag = communityFlags.find(flag => flag.code === code);
         return communityFlag?.flag || '';
       }
       return '';

--- a/src/components/PatentsRegionalChart.tsx
+++ b/src/components/PatentsRegionalChart.tsx
@@ -12,7 +12,7 @@ import {
   ChartEvent
 } from 'chart.js';
 // Importar datos de banderas de comunidades autónomas
-import autonomousCommunitiesFlagsData from '../logos/autonomous_communities_flags.json';
+import { communityFlags } from '../utils/spanishCommunitiesUtils';
 
 // Registrar componentes necesarios de Chart.js
 ChartJS.register(
@@ -112,15 +112,7 @@ const autonomousCommunitiesMapping: Record<string, {es: string, en: string, flag
   'ES64': {es: 'Ciudad de Melilla', en: 'City of Melilla', flag: '🏴󠁥󠁳󠁭󠁬󠁿', provinces: ['Melilla']}
 };
 
-// Interfaz para los elementos del archivo de banderas de comunidades autónomas
-interface AutonomousCommunityFlag {
-  community: string;
-  code: string;
-  flag: string;
-}
-
-// Asegurar el tipo correcto para el array de banderas
-const autonomousCommunitiesFlags = autonomousCommunitiesFlagsData as AutonomousCommunityFlag[];
+// Las banderas de comunidades autónomas se importan desde utilitarios compartidos
 
 // Función para obtener la URL de la bandera de la comunidad autónoma
 const getAutonomousCommunityFlagUrl = (regionCode: string): string => {
@@ -150,7 +142,7 @@ const getAutonomousCommunityFlagUrl = (regionCode: string): string => {
   const flagCode = nutsToFlagCodeMapping[regionCode];
   if (!flagCode) return '';
   
-  const flagData = autonomousCommunitiesFlags.find(flag => flag.code === flagCode);
+  const flagData = communityFlags.find(flag => flag.code === flagCode);
   return flagData?.flag || '';
 };
 

--- a/src/components/PatentsRegionalTimelineChart.tsx
+++ b/src/components/PatentsRegionalTimelineChart.tsx
@@ -9,7 +9,7 @@ import {
   Customized
 } from 'recharts';
 import { ChevronDown } from 'lucide-react';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { communityFlags } from '../utils/spanishCommunitiesUtils';
 
 // Interfaz para los datos de patentes regionales
 interface RegionalPatentsData {
@@ -194,10 +194,10 @@ const FlagImage = ({
   
   // Buscar bandera de comunidad
   if (community === 'Canarias') {
-    const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+    const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
     flagUrl = canaryFlag?.flag || '';
   } else {
-    const communityFlag = autonomous_communities_flags.find(flag => 
+    const communityFlag = communityFlags.find(flag =>
       flag.community.toLowerCase().includes(community.toLowerCase()) ||
       community.toLowerCase().includes(flag.community.toLowerCase())
     );
@@ -247,10 +247,10 @@ const FlagsCustomComponent = (props: {
   // Función para obtener URL de bandera
   const getFlagUrl = (community: string) => {
     if (community === 'Canarias') {
-      const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+      const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
       return canaryFlag?.flag || '';
     } else {
-      const communityFlag = autonomous_communities_flags.find(flag => 
+      const communityFlag = communityFlags.find(flag =>
         flag.community.toLowerCase().includes(community.toLowerCase()) ||
         community.toLowerCase().includes(flag.community.toLowerCase())
       );

--- a/src/components/RDComparisonChart.tsx
+++ b/src/components/RDComparisonChart.tsx
@@ -12,7 +12,7 @@ import {
   ChevronDown
 } from 'lucide-react';
 import country_flags from '../logos/country_flags.json';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { communityFlags } from '../utils/spanishCommunitiesUtils';
 
 // Interfaz para los datos de PIB y gasto en I+D
 interface GDPConsolidadoData {
@@ -192,7 +192,7 @@ const RDComparisonChart: React.FC<RDComparisonChartProps> = ({
       const euFlag = country_flags.find(flag => flag.iso3 === 'EUU');
       flagUrl = euFlag?.flag || 'https://flagcdn.com/eu.svg';
     } else if (type === 'canary') {
-      const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+      const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
       flagUrl = canaryFlag?.flag || '';
     } else if (type === 'country' && iso3) {
       const countryFlag = country_flags.find(flag => flag.iso3 === iso3);
@@ -472,7 +472,7 @@ const RDComparisonChart: React.FC<RDComparisonChartProps> = ({
         const euFlag = country_flags.find(flag => flag.iso3 === 'EUU');
         return euFlag?.flag || 'https://flagcdn.com/eu.svg';
       } else if (type === 'canary') {
-        const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+        const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
         return canaryFlag?.flag || '';
       } else if (type === 'country' && iso3) {
         const countryFlag = country_flags.find(flag => flag.iso3 === iso3);

--- a/src/components/RegionRankingChart.tsx
+++ b/src/components/RegionRankingChart.tsx
@@ -13,21 +13,12 @@ import {
   Chart
 } from 'chart.js';
 import * as d3 from 'd3';
-// Importando datos de autonomous_communities_flags.json
-import communityFlagsData from '../logos/autonomous_communities_flags.json';
+import { communityFlags, communityNameMapping } from '../utils/spanishCommunitiesUtils';
 import { DataDisplayType } from './DataTypeSelector';
 // Primero, importamos los colores del sector
 import { SECTOR_COLORS } from '../utils/colors';
 
-// Interfaz para los elementos del archivo autonomous_communities_flags.json
-interface CommunityFlag {
-  community: string;
-  code: string;
-  flag: string;
-}
-
-// Aseguramos el tipo correcto para el array de flags
-const communityFlags = communityFlagsData as CommunityFlag[];
+// Las banderas de las comunidades y el mapeo de nombres provienen de utilitarios compartidos
 
 // Registrar componentes necesarios de Chart.js
 ChartJS.register(
@@ -102,27 +93,6 @@ const getSectorPalette = (sectorId: string) => {
 };
 
 // Tabla de mapeo entre nombres de comunidades en el CSV y nombres esperados para la visualización
-const communityNameMapping: { [key: string]: { es: string, en: string } } = {
-  'Andalucía': { es: 'Andalucía', en: 'Andalusia' },
-  'Aragón': { es: 'Aragón', en: 'Aragon' },
-  'Principado de Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Illes Balears / Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Cantabria': { es: 'Cantabria', en: 'Cantabria' },
-  'Castilla - La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla y León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Cataluña': { es: 'Cataluña', en: 'Catalonia' },
-  'Comunidad Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Extremadura': { es: 'Extremadura', en: 'Extremadura' },
-  'Galicia': { es: 'Galicia', en: 'Galicia' },
-  'La Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Comunidad de Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Región de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Comunidad Foral de Navarra': { es: 'Navarra', en: 'Navarre' },
-  'País Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Ciudad Autónoma de Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ciudad Autónoma de Melilla': { es: 'Melilla', en: 'Melilla' }
-};
 
 const RegionRankingChart: React.FC<RegionRankingChartProps> = ({ 
   data, 

--- a/src/components/ResearchersCommunitiesTimelineChart.tsx
+++ b/src/components/ResearchersCommunitiesTimelineChart.tsx
@@ -10,7 +10,7 @@ import {
 } from 'recharts';
 import { ChevronDown } from 'lucide-react';
 import country_flags from '../logos/country_flags.json';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { communityFlags } from '../utils/spanishCommunitiesUtils';
 import {
   ResearchersCommunityData,
   getCommunityValue,
@@ -100,11 +100,11 @@ const FlagImage = ({
   } else if (type === 'community' && code) {
     // Buscar bandera de comunidad
     if (code === 'canarias') {
-      const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+      const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
       flagUrl = canaryFlag?.flag || '';
     } else {
       // Buscar por nombre de comunidad
-      const communityFlag = autonomous_communities_flags.find(flag => 
+      const communityFlag = communityFlags.find(flag =>
         flag.community.toLowerCase().includes(code.toLowerCase()) ||
         flag.code.toLowerCase() === code.toLowerCase()
       );
@@ -159,10 +159,10 @@ const FlagsCustomComponent = (props: {
       return esFlag?.flag || '/logos/spain.svg';
     } else if (type === 'community' && code) {
       if (code === 'canarias') {
-        const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');
+        const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');
         return canaryFlag?.flag || '';
       } else {
-        const communityFlag = autonomous_communities_flags.find(flag => 
+        const communityFlag = communityFlags.find(flag =>
           flag.community.toLowerCase().includes(code.toLowerCase()) ||
           flag.code.toLowerCase() === code.toLowerCase()
         );

--- a/src/components/ResearchersSpanishRegionsMap.tsx
+++ b/src/components/ResearchersSpanishRegionsMap.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import * as d3 from 'd3';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { communityFlags, communityNameMapping, normalizarTexto } from '../utils/spanishCommunitiesUtils';
 
 // Definir colores específicos para los componentes de investigadores
 // Estos son los mismos que se usan en ResearchersEuropeanMap.tsx
@@ -19,14 +19,6 @@ const NO_DATA_COLOR = '#f5f5f5';
 const SPAIN_GEOJSON_URL = '/data/geo/spain-communities.geojson';
 
 // Interfaces y tipos
-interface CommunityFlag {
-  community: string;
-  code: string;
-  flag: string;
-}
-
-// Aseguramos el tipo correcto para el array de flags
-const communityFlags = autonomous_communities_flags as CommunityFlag[];
 
 // Tipo para mostrar datos
 type DataDisplayType = 'researchers_count' | 'researchers_per_thousand';
@@ -114,72 +106,6 @@ const mapTexts = {
 
 // Tabla de mapeo entre nombres de comunidades en el CSV y nombres en GeoJSON
 // Esto ayuda a estandarizar los nombres entre diferentes formatos
-const communityNameMapping: { [key: string]: { es: string, en: string } } = {
-  'Andalucía': { es: 'Andalucía', en: 'Andalusia' },
-  'Andalucia': { es: 'Andalucía', en: 'Andalusia' },
-  'Aragón': { es: 'Aragón', en: 'Aragon' },
-  'Aragon': { es: 'Aragón', en: 'Aragon' },
-  'Principado de Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Illes Balears / Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Illes Balears': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Balearic Islands': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Islas Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Canary Islands': { es: 'Canarias', en: 'Canary Islands' },
-  'Cantabria': { es: 'Cantabria', en: 'Cantabria' },
-  'Castilla - La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-la Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castillalamancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla y León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla y Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Cataluña': { es: 'Cataluña', en: 'Catalonia' },
-  'Cataluna': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalunya': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalonia': { es: 'Cataluña', en: 'Catalonia' },
-  'Comunidad Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'C. Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencia': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencian Community': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Extremadura': { es: 'Extremadura', en: 'Extremadura' },
-  'Galicia': { es: 'Galicia', en: 'Galicia' },
-  'La Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Comunidad de Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Región de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Region de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Comunidad Foral de Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarre': { es: 'Navarra', en: 'Navarre' },
-  'País Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Pais Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Euskadi': { es: 'País Vasco', en: 'Basque Country' },
-  'Basque Country': { es: 'País Vasco', en: 'Basque Country' },
-  'Ciudad Autónoma de Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ciudad Autónoma de Melilla': { es: 'Melilla', en: 'Melilla' },
-  'Melilla': { es: 'Melilla', en: 'Melilla' }
-};
-
-// Función para normalizar texto (remover acentos y caracteres especiales)
-function normalizarTexto(texto: string | undefined): string {
-  if (!texto) return '';
-  return texto
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase();
-}
 
 // Función para obtener el nombre de la comunidad de las propiedades GeoJSON
 function getCommunityName(feature: GeoJsonFeature, language: 'es' | 'en'): string {

--- a/src/components/SectorDistribution.tsx
+++ b/src/components/SectorDistribution.tsx
@@ -4,7 +4,7 @@ import { Calendar, ChevronDown } from 'lucide-react';
 import Papa from 'papaparse';
 import { rdSectors } from '../data/rdInvestment';
 import country_flags from '../logos/country_flags.json';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { communityFlags } from '../utils/spanishCommunitiesUtils';
 
 // Interfaces para los datos CSV
 interface GDPConsolidadoData {
@@ -78,7 +78,7 @@ const Flag: React.FC<FlagProps> = ({ code, width = 24, height = 18, className = 
   // Búsqueda de banderas en los JSON
   const euFlag = country_flags.find(flag => flag.iso3 === 'EUU');
   const esFlag = country_flags.find(flag => flag.iso3 === 'ESP');
-  const canaryFlag = autonomous_communities_flags.find(community => community.code === 'CAN');
+  const canaryFlag = communityFlags.find(community => community.code === 'CAN');
   const countryFlag = code === 'country' && iso3 ? country_flags.find(flag => flag.iso3 === iso3) : null;
   
   switch(code) {
@@ -91,7 +91,7 @@ const Flag: React.FC<FlagProps> = ({ code, width = 24, height = 18, className = 
       flagUrl = esFlag?.flag || '';
       break;
     case 'canary_islands':
-      // Usar bandera de Canarias desde autonomous_communities_flags.json
+      // Usar bandera de Canarias desde el utilitario compartido
       flagUrl = canaryFlag?.flag || '';
       // Agregar estilos especiales para la bandera de Canarias
       extraStyles = 'border border-gray-200 shadow-sm bg-gray-50';

--- a/src/components/SectorEvolutionChart.tsx
+++ b/src/components/SectorEvolutionChart.tsx
@@ -1,17 +1,15 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { 
-  LineChart, 
-  Line, 
-  XAxis, 
-  YAxis, 
-  Tooltip, 
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
   ResponsiveContainer,
   Legend
 } from 'recharts';
-import { 
-  ChevronDown
-} from 'lucide-react';
-import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { ChevronDown } from 'lucide-react';
+import { communityFlags, communityNameMapping } from '../utils/spanishCommunitiesUtils';
 
 // Interfaz para los datos de comunidades autónomas
 interface GastoIDComunidadesData {
@@ -52,63 +50,6 @@ interface SectorEvolutionChartProps {
 }
 
 // Tabla de mapeo entre nombres de comunidades en el CSV y nombres en español/inglés
-const communityNameMapping: { [key: string]: { es: string, en: string } } = {
-  'Andalucía': { es: 'Andalucía', en: 'Andalusia' },
-  'Andalucia': { es: 'Andalucía', en: 'Andalusia' },
-  'Aragón': { es: 'Aragón', en: 'Aragon' },
-  'Aragon': { es: 'Aragón', en: 'Aragon' },
-  'Principado de Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Illes Balears / Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Illes Balears': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Balearic Islands': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Islas Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Canary Islands': { es: 'Canarias', en: 'Canary Islands' },
-  'Cantabria': { es: 'Cantabria', en: 'Cantabria' },
-  'Castilla - La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-la Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castillalamancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla y León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla y Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Cataluña': { es: 'Cataluña', en: 'Catalonia' },
-  'Cataluna': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalunya': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalonia': { es: 'Cataluña', en: 'Catalonia' },
-  'Comunidad Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'C. Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencia': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencian Community': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Extremadura': { es: 'Extremadura', en: 'Extremadura' },
-  'Galicia': { es: 'Galicia', en: 'Galicia' },
-  'La Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Comunidad de Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Región de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Region de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Comunidad Foral de Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarre': { es: 'Navarra', en: 'Navarre' },
-  'País Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Pais Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Euskadi': { es: 'País Vasco', en: 'Basque Country' },
-  'Basque Country': { es: 'País Vasco', en: 'Basque Country' },
-  'Ciudad Autónoma de Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ciudad Autónoma de Melilla': { es: 'Melilla', en: 'Melilla' },
-  'Melilla': { es: 'Melilla', en: 'Melilla' }
-};
 
 const SectorEvolutionChart: React.FC<SectorEvolutionChartProps> = ({
   language,
@@ -215,7 +156,7 @@ const SectorEvolutionChart: React.FC<SectorEvolutionChartProps> = ({
         }
         
         // Buscar la comunidad en el objeto de banderas
-        const flag = autonomous_communities_flags.find(f => 
+        const flag = communityFlags.find(f =>
           normalizeText(f.community) === normalizeText(communityName) || 
           f.community.includes(originalName.replace(/\(ES\d+\)\s/, ''))
         );
@@ -508,7 +449,7 @@ const SectorEvolutionChart: React.FC<SectorEvolutionChartProps> = ({
   
   // Componente para mostrar la bandera de la comunidad
   const CommunityFlag = ({ code }: { code: string }) => {
-    const flag = autonomous_communities_flags.find(f => f.code === code);
+    const flag = communityFlags.find(f => f.code === code);
     
     if (!flag) return null;
     

--- a/src/components/SpanishRegionsMap.tsx
+++ b/src/components/SpanishRegionsMap.tsx
@@ -2,19 +2,10 @@ import React, { useRef, useState, useEffect } from 'react';
 import * as d3 from 'd3';
 import { Feature, Geometry } from 'geojson';
 import { SECTOR_COLORS } from '../utils/colors';
-// Importando datos de autonomous_communities_flags.json
-import communityFlagsData from '../logos/autonomous_communities_flags.json';
+import { communityFlags, communityNameMapping, normalizarTexto } from '../utils/spanishCommunitiesUtils';
 import { DataDisplayType } from './DataTypeSelector';
 
-// Interfaz para los elementos del archivo autonomous_communities_flags.json
-interface CommunityFlag {
-  community: string;
-  code: string;
-  flag: string;
-}
-
-// Aseguramos el tipo correcto para el array de flags
-const communityFlags = communityFlagsData as CommunityFlag[];
+// Banderas y mapeo de comunidades proporcionados por utilitarios compartidos
 
 // Interfaz para los datos de comunidades autónomas
 interface AutonomousCommunityData {
@@ -140,72 +131,6 @@ const mapTexts = {
 
 // Tabla de mapeo entre nombres de comunidades en el CSV y nombres en GeoJSON
 // Actualizado para usar el mismo formato que en RegionRankingChart.tsx
-const communityNameMapping: { [key: string]: { es: string, en: string } } = {
-  'Andalucía': { es: 'Andalucía', en: 'Andalusia' },
-  'Andalucia': { es: 'Andalucía', en: 'Andalusia' },
-  'Aragón': { es: 'Aragón', en: 'Aragon' },
-  'Aragon': { es: 'Aragón', en: 'Aragon' },
-  'Principado de Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Asturias': { es: 'Asturias', en: 'Asturias' },
-  'Illes Balears / Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Islas Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Illes Balears': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Baleares': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Balearic Islands': { es: 'Islas Baleares', en: 'Balearic Islands' },
-  'Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Islas Canarias': { es: 'Canarias', en: 'Canary Islands' },
-  'Canary Islands': { es: 'Canarias', en: 'Canary Islands' },
-  'Cantabria': { es: 'Cantabria', en: 'Cantabria' },
-  'Castilla - La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla La Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla-la Mancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castillalamancha': { es: 'Castilla-La Mancha', en: 'Castilla–La Mancha' },
-  'Castilla y León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla y Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castilla-Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and León': { es: 'Castilla y León', en: 'Castile and León' },
-  'Castile and Leon': { es: 'Castilla y León', en: 'Castile and León' },
-  'Cataluña': { es: 'Cataluña', en: 'Catalonia' },
-  'Cataluna': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalunya': { es: 'Cataluña', en: 'Catalonia' },
-  'Catalonia': { es: 'Cataluña', en: 'Catalonia' },
-  'Comunidad Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'C. Valenciana': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencia': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Valencian Community': { es: 'Com. Valenciana', en: 'Valencia' },
-  'Extremadura': { es: 'Extremadura', en: 'Extremadura' },
-  'Galicia': { es: 'Galicia', en: 'Galicia' },
-  'La Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Rioja': { es: 'La Rioja', en: 'La Rioja' },
-  'Comunidad de Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Madrid': { es: 'Madrid', en: 'Madrid' },
-  'Región de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Region de Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Murcia': { es: 'Murcia', en: 'Murcia' },
-  'Comunidad Foral de Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarra': { es: 'Navarra', en: 'Navarre' },
-  'Navarre': { es: 'Navarra', en: 'Navarre' },
-  'País Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Pais Vasco': { es: 'País Vasco', en: 'Basque Country' },
-  'Euskadi': { es: 'País Vasco', en: 'Basque Country' },
-  'Basque Country': { es: 'País Vasco', en: 'Basque Country' },
-  'Ciudad Autónoma de Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ceuta': { es: 'Ceuta', en: 'Ceuta' },
-  'Ciudad Autónoma de Melilla': { es: 'Melilla', en: 'Melilla' },
-  'Melilla': { es: 'Melilla', en: 'Melilla' }
-};
-
-// Función para normalizar texto (remover acentos y caracteres especiales)
-function normalizarTexto(texto: string | undefined): string {
-  if (!texto) return '';
-  return texto
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase();
-}
 
 // Función para obtener el nombre de la comunidad de las propiedades GeoJSON
 function getCommunityName(feature: GeoJsonFeature, language: 'es' | 'en'): string {


### PR DESCRIPTION
## Summary
- centralize autonomous community name and flag data in shared utils
- streamline country matching via ISO codes for European maps

## Testing
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6899d310fc20832884cdb25b0350ccfe