### PR TITLE
Inline Spain flag to prevent flicker

### DIFF
--- a/src/components/CommunityDistribution.tsx
+++ b/src/components/CommunityDistribution.tsx
@@ -3,6 +3,7 @@ import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 import { Calendar, ChevronDown } from 'lucide-react';
 import Papa from 'papaparse';
 import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { SPAIN_FLAG } from '../utils/spainFlag';
 
 // Definición de los sectores de I+D
 const rdSectors = [
@@ -139,7 +140,7 @@ const Flag: React.FC<FlagProps> = ({ code, width = 24, height = 18, className = 
   let extraStyles = '';
   
   // Búsqueda de banderas en el JSON
-  const esFlag = "/logos/spain.svg";
+  const esFlag = SPAIN_FLAG;
   const canaryFlag = autonomous_communities_flags.find(community => community.code === 'CAN');
   const communityFlag = code === 'community' && communityCode ? 
     autonomous_communities_flags.find(community => community.code === communityCode) : null;

--- a/src/components/EuropeanRDMap.tsx
+++ b/src/components/EuropeanRDMap.tsx
@@ -7,6 +7,7 @@ import countryFlagsData from '../logos/country_flags.json';
 import { DataDisplayType } from './DataTypeSelector';
 // Importar las funciones de mapeo de países
 import { getIso3FromCountryName, isSupranationalEntity as isSupranationalFromMapping } from '../utils/countryMapping';
+import { SPAIN_FLAG } from '../utils/spainFlag';
 // Para usar las banderas SVG, debes importarlas del archivo logos/country-flags.tsx
 // import { FlagSpain, FlagEU, FlagCanaryIslands, FlagSweden, FlagFinland } from '../logos/country-flags';
 
@@ -759,7 +760,7 @@ function getCountryFlagUrl(countryName: string, feature?: GeoJsonFeature): strin
   } else if (normalizedName.includes('zona euro') || normalizedName.includes('euro area')) {
     return "https://flagcdn.com/eu.svg"; // Usamos también la bandera de la UE para la zona euro
   } else if (normalizedName.includes('espana') || normalizedName.includes('españa') || normalizedName.includes('spain')) {
-    return "/logos/spain.svg";
+    return SPAIN_FLAG;
   } else if (normalizedName.includes('alemania') || normalizedName.includes('germany')) {
     return "https://flagcdn.com/de.svg";
   } else if (normalizedName.includes('francia') || normalizedName.includes('france')) {

--- a/src/components/PatentsEuropeanTimelineChart.tsx
+++ b/src/components/PatentsEuropeanTimelineChart.tsx
@@ -12,6 +12,7 @@ import {
 import countryFlagsData from '../logos/country_flags.json';
 import { EUROPEAN_COUNTRY_CODES } from '../utils/europeanCountries';
 import { PatentsDisplayType } from './DataTypeSelector';
+import { SPAIN_FLAG } from '../utils/spainFlag';
 
 // Definir la interfaz para los datos de patentes (igual que en la página principal)
 interface PatentsData {
@@ -97,7 +98,7 @@ const FlagsCustomComponent = (props: {
       return 'https://flagcdn.com/eu.svg';
     }
     if (type === 'es') {
-      return '/logos/spain.svg';
+      return SPAIN_FLAG;
     }
     if (type === 'country' && code) {
       // Buscar en el archivo de banderas
@@ -520,7 +521,7 @@ const PatentsEuropeanTimelineChart: React.FC<PatentsEuropeanTimelineChartProps> 
   }) => {
     const getFlagUrl = (type: 'eu' | 'es' | 'country', code?: string) => {
       if (type === 'eu') return 'https://flagcdn.com/eu.svg';
-      if (type === 'es') return '/logos/spain.svg';
+      if (type === 'es') return SPAIN_FLAG;
       if (type === 'country' && code) {
         const foundFlag = countryFlags.find(flag => 
           flag.code.toUpperCase() === code.toUpperCase() ||

--- a/src/components/PatentsTimelineChart.tsx
+++ b/src/components/PatentsTimelineChart.tsx
@@ -11,6 +11,7 @@ import {
 } from 'recharts';
 // Importando datos de country_flags.json
 import countryFlagsData from '../logos/country_flags.json';
+import { SPAIN_FLAG } from '../utils/spainFlag';
 
 // Definir la interfaz para los datos de patentes
 interface PatentsData {
@@ -101,7 +102,7 @@ const FlagsCustomComponent = (props: {
       return 'https://flagcdn.com/eu.svg';
     }
     if (type === 'es') {
-      return '/logos/spain.svg';
+      return SPAIN_FLAG;
     }
     if (type === 'country' && code) {
       // Buscar en el archivo de banderas
@@ -575,7 +576,7 @@ const PatentsTimelineChart: React.FC<PatentsTimelineChartProps> = ({
     } else if (type === 'es') {
       // Bandera de España
       const esFlag = countryFlags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      flagUrl = esFlag?.flag || "/logos/spain.svg";
+      flagUrl = esFlag?.flag || SPAIN_FLAG;
     } else if (type === 'country' && code) {
       // Manejar casos especiales
       if (code === 'EL') {

--- a/src/components/ResearchersCommunitiesTimelineChart.tsx
+++ b/src/components/ResearchersCommunitiesTimelineChart.tsx
@@ -11,6 +11,7 @@ import {
 import { ChevronDown } from 'lucide-react';
 import country_flags from '../logos/country_flags.json';
 import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { SPAIN_FLAG } from '../utils/spainFlag';
 import {
   ResearchersCommunityData,
   getCommunityValue,
@@ -96,7 +97,7 @@ const FlagImage = ({
   if (type === 'country' && code === 'ES') {
     // Bandera de España
     const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-    flagUrl = esFlag?.flag || '/logos/spain.svg';
+    flagUrl = esFlag?.flag || SPAIN_FLAG;
   } else if (type === 'community' && code) {
     // Buscar bandera de comunidad
     if (code === 'canarias') {
@@ -156,7 +157,7 @@ const FlagsCustomComponent = (props: {
   const getFlagUrl = (type: 'country' | 'community', code?: string) => {
     if (type === 'country' && code === 'ES') {
       const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      return esFlag?.flag || '/logos/spain.svg';
+      return esFlag?.flag || SPAIN_FLAG;
     } else if (type === 'community' && code) {
       if (code === 'canarias') {
         const canaryFlag = autonomous_communities_flags.find(flag => flag.code === 'CAN');

--- a/src/components/ResearchersTimelineChart.tsx
+++ b/src/components/ResearchersTimelineChart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'recharts';
 import { ChevronDown } from 'lucide-react';
 import country_flags from '../logos/country_flags.json';
+import { SPAIN_FLAG } from '../utils/spainFlag';
 
 // Interfaz para los datos de investigadores
 interface ResearchersData {
@@ -119,7 +120,7 @@ const FlagsCustomComponent = (props: {
       return euFlag?.flag || "https://flagcdn.com/eu.svg";
     } else if (type === 'es') {
       const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      return esFlag?.flag || "/logos/spain.svg";
+      return esFlag?.flag || SPAIN_FLAG;
     } else if (type === 'country' && code) {
       if (code === 'EL') {
         const greeceFlag = country_flags.find(flag => flag.code === 'GR' || flag.iso3 === 'GRC');
@@ -644,7 +645,7 @@ const ResearchersTimelineChart: React.FC<ResearchersTimelineChartProps> = ({
     } else if (type === 'es') {
       // Bandera de España
       const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      flagUrl = esFlag?.flag || "/logos/spain.svg";
+      flagUrl = esFlag?.flag || SPAIN_FLAG;
     } else if (type === 'country' && code) {
       // Manejar el caso especial de Grecia (EL)
       if (code === 'EL') {

--- a/src/logos/country_flags.json
+++ b/src/logos/country_flags.json
@@ -351,7 +351,7 @@
     "country": "España",
     "code": "ES",
     "iso3": "ESP",
-    "flag": "/logos/spain.svg"
+    "flag": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzIDIiPgogIDxyZWN0IHdpZHRoPSIzIiBoZWlnaHQ9IjIiIGZpbGw9IiNjNjBiMWUiLz4KICA8cmVjdCB5PSIwLjUiIHdpZHRoPSMzIiBoZWlnaHQ9IjEiIGZpbGw9IiNmZmM0MDAiLz4KPC9zdmc+Cg=="
   },
   {
     "country": "Estados Unidos",

--- a/src/pages/Investment/index.tsx
+++ b/src/pages/Investment/index.tsx
@@ -11,6 +11,7 @@ import { DATA_PATHS, rdSectors } from '../../data/rdInvestment';
 import CommunityDistribution from '../../components/CommunityDistribution';
 import CommunityRDComparisonChart from '../../components/CommunityRDComparisonChart';
 import SectorEvolutionChart from '../../components/SectorEvolutionChart';
+import { SPAIN_FLAG } from '../../utils/spainFlag';
 
 // Interfaz para los datos de comunidades autónomas
 interface AutonomousCommunityData {
@@ -640,7 +641,7 @@ const Investment: React.FC<InvestmentProps> = ({ language }) => {
                   <div className="flex-shrink-0 mr-3">
                     <div className="p-2 sm:p-3 bg-red-50 rounded-lg flex items-center justify-center">
                       <img
-                        src="/logos/spain.svg"
+                        src={SPAIN_FLAG}
                         alt="Bandera de España"
                         className="w-6 h-4 sm:w-8 sm:h-6 object-cover rounded border border-gray-300 shadow-sm"
                         style={{

--- a/src/utils/countryMapping.ts
+++ b/src/utils/countryMapping.ts
@@ -5,6 +5,8 @@
  * y su mapeo a códigos ISO2 e ISO3 para asegurar consistencia en la visualización de mapas.
  */
 
+import { SPAIN_FLAG } from './spainFlag';
+
 // Interfaz para el mapeo de países
 export interface CountryMapping {
   // Nombres del país en diferentes idiomas e identificaciones
@@ -137,7 +139,7 @@ export const countryMappings: Record<string, CountryMapping> = {
     },
     iso2: "ES",
     iso3: "ESP",
-    flag: "/logos/spain.svg"
+    flag: SPAIN_FLAG
   },
   "FR": {
     names: {

--- a/src/utils/spainFlag.ts
+++ b/src/utils/spainFlag.ts
@@ -1,0 +1,1 @@
+export const SPAIN_FLAG = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzIDIiPgogIDxyZWN0IHdpZHRoPSIzIiBoZWlnaHQ9IjIiIGZpbGw9IiNjNjBiMWUiLz4KICA8cmVjdCB5PSIwLjUiIHdpZHRoPSIzIiBoZWlnaHQ9IjEiIGZpbGw9IiNmZmM0MDAiLz4KPC9zdmc+Cg==";

--- a/src/utils/spanishCommunitiesUtils.ts
+++ b/src/utils/spanishCommunitiesUtils.ts
@@ -1,4 +1,5 @@
 import autonomous_communities_flags from '../logos/autonomous_communities_flags.json';
+import { SPAIN_FLAG } from './spainFlag';
 
 // Interfaz para los datos de investigadores por comunidades autónomas
 export interface ResearchersCommunityData {
@@ -228,7 +229,7 @@ export function getCommunityValue(
 
 // Función unificada para obtener la bandera de una comunidad
 export function getCommunityFlagUrl(communityName: string, language: 'es' | 'en'): string {
-  if (!communityName) return "/logos/spain.svg";
+  if (!communityName) return SPAIN_FLAG;
   
   const possibleNames = [communityName];
   
@@ -357,7 +358,7 @@ export function getCommunityFlagUrl(communityName: string, language: 'es' | 'en'
   }
   
   // Fallback: bandera de España
-  return "/logos/spain.svg";
+  return SPAIN_FLAG;
 }
 
 // Función para obtener el valor de España (total nacional)


### PR DESCRIPTION
## Summary
- Embed Spain's flag as a base64 SVG constant and use it throughout the app
- Replace all references to `/logos/spain.svg` with the inlined constant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/ban-types' was not found and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899d4f983308328bd53e4bfc865efc4