### PR TITLE
fix: adjust Canary Islands map box

### DIFF
--- a/src/components/SpanishRegionsMap.tsx
+++ b/src/components/SpanishRegionsMap.tsx
@@ -1048,7 +1048,7 @@ const SpanishRegionsMap: React.FC<SpanishRegionsMapProps> = ({
       
       // MEJORA: Ajustar escala para utilizar más espacio disponible
       const peninsulaScale = containerWidth * 2.8; // Reducido de 3.2 a 2.8 para hacer el mapa más pequeño
-      const canariasScale = containerWidth * 2.3; // Aumentado de 2.0 a 2.3 para que las islas se vean más grandes
+      const canariasScale = containerWidth * 2.5; // Mantener proporción similar al mapa de investigadores
       
       // Crear proyección para España peninsular (centrada y escalada para maximizar el espacio)
       const projectionMainland = d3.geoMercator()
@@ -1059,8 +1059,8 @@ const SpanishRegionsMap: React.FC<SpanishRegionsMapProps> = ({
       // Crear proyección específica para las Islas Canarias
       const projectionCanarias = d3.geoMercator()
         .center([-15.5, 28.2])
-        .scale(canariasScale) // Aumentado de 2.0 a 2.3 para que las islas se vean más grandes
-        .translate([containerWidth * 0.14, containerHeight * 0.74]); // Centrado perfecto en el recuadro (horizontal: 0.02 + 0.24/2 = 0.14, vertical: 0.66 + 0.16/2 = 0.74)
+        .scale(canariasScale) // Aumentado para que las islas se vean más grandes
+        .translate([containerWidth * 0.14, containerHeight * 0.80]); // Alinear posición con el mapa de investigadores
       
       // Crear proyección específica para Ceuta y Melilla (compartirán recuadro)
       const projectionCeuta = d3.geoMercator()
@@ -1831,9 +1831,9 @@ const SpanishRegionsMap: React.FC<SpanishRegionsMapProps> = ({
         // Fondo blanco translúcido para el recuadro - ajustar posición y tamaño
         canariasGroup.append('rect')
           .attr('x', containerWidth * 0.02) // Más a la izquierda
-          .attr('y', containerHeight * 0.66) // Mover más arriba para que no se salga del contenedor
+          .attr('y', containerHeight * 0.68) // Ajuste para alinear con el mapa de investigadores
           .attr('width', containerWidth * 0.24) // Mantener ancho
-          .attr('height', containerHeight * 0.16) // Aumentado de 0.12 a 0.16 para que las islas se vean completas
+          .attr('height', containerHeight * 0.20) // Altura extendida para cerrar el recuadro
           .attr('rx', 4) 
           .attr('ry', 4)
           .attr('fill', 'rgba(255, 255, 255, 0.8)')
@@ -1844,9 +1844,9 @@ const SpanishRegionsMap: React.FC<SpanishRegionsMapProps> = ({
         
         // Etiqueta para Canarias - ajustar posición
         canariasGroup.append('text')
-          .attr('x', containerWidth * 0.04) 
-          .attr('y', containerHeight * 0.68) // Ajustar posición por recuadro movido más arriba
-          .attr('font-size', '8px') 
+          .attr('x', containerWidth * 0.04)
+          .attr('y', containerHeight * 0.71) // Alineado con nuevo recuadro
+          .attr('font-size', '10px')
           .attr('font-weight', 'bold')
           .attr('fill', '#0077b6')
           .attr('class', 'canarias-label')


### PR DESCRIPTION
## Summary
- align Canary Islands projection and bounding box with researchers map
- enlarge rectangle and label to close box

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6899d5d08b0c832894c4fe7c779334eb