### PR TITLE
Use CDN Spanish flag and reposition Canary Islands inset

### DIFF
--- a/public/logos/spain.svg
+++ b/public/logos/spain.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
-  <rect width="3" height="2" fill="#c60b1e"/>
-  <rect y="0.5" width="3" height="1" fill="#ffc400"/>
-</svg>

--- a/src/components/CommunityDistribution.tsx
+++ b/src/components/CommunityDistribution.tsx
@@ -139,7 +139,7 @@ const Flag: React.FC<FlagProps> = ({ code, width = 24, height = 18, className = 
   let extraStyles = '';
   
   // Búsqueda de banderas en el JSON
-  const esFlag = "/logos/spain.svg";
+  const esFlag = "https://flagcdn.com/es.svg";
   const canaryFlag = communityFlags.find(community => community.code === 'CAN');
   const communityFlag = code === 'community' && communityCode ?
     communityFlags.find(community => community.code === communityCode) : null;

--- a/src/components/EuropeanRDMap.tsx
+++ b/src/components/EuropeanRDMap.tsx
@@ -720,7 +720,7 @@ function getCountryFlagUrl(countryName: string, feature?: GeoJsonFeature): strin
   } else if (normalizedName.includes('zona euro') || normalizedName.includes('euro area')) {
     return "https://flagcdn.com/eu.svg"; // Usamos también la bandera de la UE para la zona euro
   } else if (normalizedName.includes('espana') || normalizedName.includes('españa') || normalizedName.includes('spain')) {
-    return "/logos/spain.svg";
+    return "https://flagcdn.com/es.svg";
   } else if (normalizedName.includes('alemania') || normalizedName.includes('germany')) {
     return "https://flagcdn.com/de.svg";
   } else if (normalizedName.includes('francia') || normalizedName.includes('france')) {

--- a/src/components/PatentsEuropeanTimelineChart.tsx
+++ b/src/components/PatentsEuropeanTimelineChart.tsx
@@ -97,7 +97,7 @@ const FlagsCustomComponent = (props: {
       return 'https://flagcdn.com/eu.svg';
     }
     if (type === 'es') {
-      return '/logos/spain.svg';
+      return 'https://flagcdn.com/es.svg';
     }
     if (type === 'country' && code) {
       // Buscar en el archivo de banderas
@@ -520,7 +520,7 @@ const PatentsEuropeanTimelineChart: React.FC<PatentsEuropeanTimelineChartProps> 
   }) => {
     const getFlagUrl = (type: 'eu' | 'es' | 'country', code?: string) => {
       if (type === 'eu') return 'https://flagcdn.com/eu.svg';
-      if (type === 'es') return '/logos/spain.svg';
+      if (type === 'es') return 'https://flagcdn.com/es.svg';
       if (type === 'country' && code) {
         const foundFlag = countryFlags.find(flag => 
           flag.code.toUpperCase() === code.toUpperCase() ||

--- a/src/components/PatentsTimelineChart.tsx
+++ b/src/components/PatentsTimelineChart.tsx
@@ -101,7 +101,7 @@ const FlagsCustomComponent = (props: {
       return 'https://flagcdn.com/eu.svg';
     }
     if (type === 'es') {
-      return '/logos/spain.svg';
+      return 'https://flagcdn.com/es.svg';
     }
     if (type === 'country' && code) {
       // Buscar en el archivo de banderas
@@ -575,7 +575,7 @@ const PatentsTimelineChart: React.FC<PatentsTimelineChartProps> = ({
     } else if (type === 'es') {
       // Bandera de España
       const esFlag = countryFlags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      flagUrl = esFlag?.flag || "/logos/spain.svg";
+      flagUrl = esFlag?.flag || "https://flagcdn.com/es.svg";
     } else if (type === 'country' && code) {
       // Manejar casos especiales
       if (code === 'EL') {

--- a/src/components/ResearchersCommunitiesTimelineChart.tsx
+++ b/src/components/ResearchersCommunitiesTimelineChart.tsx
@@ -96,7 +96,7 @@ const FlagImage = ({
   if (type === 'country' && code === 'ES') {
     // Bandera de España
     const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-    flagUrl = esFlag?.flag || '/logos/spain.svg';
+    flagUrl = esFlag?.flag || 'https://flagcdn.com/es.svg';
   } else if (type === 'community' && code) {
     // Buscar bandera de comunidad
     if (code === 'canarias') {
@@ -156,7 +156,7 @@ const FlagsCustomComponent = (props: {
   const getFlagUrl = (type: 'country' | 'community', code?: string) => {
     if (type === 'country' && code === 'ES') {
       const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      return esFlag?.flag || '/logos/spain.svg';
+      return esFlag?.flag || 'https://flagcdn.com/es.svg';
     } else if (type === 'community' && code) {
       if (code === 'canarias') {
         const canaryFlag = communityFlags.find(flag => flag.code === 'CAN');

--- a/src/components/ResearchersTimelineChart.tsx
+++ b/src/components/ResearchersTimelineChart.tsx
@@ -119,7 +119,7 @@ const FlagsCustomComponent = (props: {
       return euFlag?.flag || "https://flagcdn.com/eu.svg";
     } else if (type === 'es') {
       const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      return esFlag?.flag || "/logos/spain.svg";
+      return esFlag?.flag || "https://flagcdn.com/es.svg";
     } else if (type === 'country' && code) {
       if (code === 'EL') {
         const greeceFlag = country_flags.find(flag => flag.code === 'GR' || flag.iso3 === 'GRC');
@@ -644,7 +644,7 @@ const ResearchersTimelineChart: React.FC<ResearchersTimelineChartProps> = ({
     } else if (type === 'es') {
       // Bandera de España
       const esFlag = country_flags.find(flag => flag.code === 'ES' || flag.iso3 === 'ESP');
-      flagUrl = esFlag?.flag || "/logos/spain.svg";
+      flagUrl = esFlag?.flag || "https://flagcdn.com/es.svg";
     } else if (type === 'country' && code) {
       // Manejar el caso especial de Grecia (EL)
       if (code === 'EL') {

--- a/src/components/SpanishRegionsMap.tsx
+++ b/src/components/SpanishRegionsMap.tsx
@@ -1756,10 +1756,10 @@ const SpanishRegionsMap: React.FC<SpanishRegionsMapProps> = ({
         // Fondo blanco translúcido para el recuadro - ajustar posición y tamaño
         canariasGroup.append('rect')
           .attr('x', containerWidth * 0.02) // Más a la izquierda
-          .attr('y', containerHeight * 0.68) // Ajuste para alinear con el mapa de investigadores
+          .attr('y', containerHeight * 0.58) // Subir el recuadro para mantenerlo visible
           .attr('width', containerWidth * 0.24) // Mantener ancho
           .attr('height', containerHeight * 0.20) // Altura extendida para cerrar el recuadro
-          .attr('rx', 4) 
+          .attr('rx', 4)
           .attr('ry', 4)
           .attr('fill', 'rgba(255, 255, 255, 0.8)')
           .attr('stroke', '#0077b6')
@@ -1770,7 +1770,7 @@ const SpanishRegionsMap: React.FC<SpanishRegionsMapProps> = ({
         // Etiqueta para Canarias - ajustar posición
         canariasGroup.append('text')
           .attr('x', containerWidth * 0.04)
-          .attr('y', containerHeight * 0.71) // Alineado con nuevo recuadro
+          .attr('y', containerHeight * 0.61) // Ajustar posición acorde al nuevo recuadro
           .attr('font-size', '10px')
           .attr('font-weight', 'bold')
           .attr('fill', '#0077b6')

--- a/src/logos/country_flags.json
+++ b/src/logos/country_flags.json
@@ -351,7 +351,7 @@
     "country": "España",
     "code": "ES",
     "iso3": "ESP",
-    "flag": "/logos/spain.svg"
+    "flag": "https://flagcdn.com/es.svg"
   },
   {
     "country": "Estados Unidos",

--- a/src/pages/Investment/index.tsx
+++ b/src/pages/Investment/index.tsx
@@ -640,7 +640,7 @@ const Investment: React.FC<InvestmentProps> = ({ language }) => {
                   <div className="flex-shrink-0 mr-3">
                     <div className="p-2 sm:p-3 bg-red-50 rounded-lg flex items-center justify-center">
                       <img
-                        src="/logos/spain.svg"
+                        src="https://flagcdn.com/es.svg"
                         alt="Bandera de España"
                         className="w-6 h-4 sm:w-8 sm:h-6 object-cover rounded border border-gray-300 shadow-sm"
                         style={{

--- a/src/utils/countryMapping.ts
+++ b/src/utils/countryMapping.ts
@@ -137,7 +137,7 @@ export const countryMappings: Record<string, CountryMapping> = {
     },
     iso2: "ES",
     iso3: "ESP",
-    flag: "/logos/spain.svg"
+    flag: "https://flagcdn.com/es.svg"
   },
   "FR": {
     names: {

--- a/src/utils/spanishCommunitiesUtils.ts
+++ b/src/utils/spanishCommunitiesUtils.ts
@@ -228,7 +228,7 @@ export function getCommunityValue(
 
 // Función unificada para obtener la bandera de una comunidad
 export function getCommunityFlagUrl(communityName: string, language: 'es' | 'en'): string {
-  if (!communityName) return "/logos/spain.svg";
+  if (!communityName) return "https://flagcdn.com/es.svg";
   
   const possibleNames = [communityName];
   
@@ -357,7 +357,7 @@ export function getCommunityFlagUrl(communityName: string, language: 'es' | 'en'
   }
   
   // Fallback: bandera de España
-  return "/logos/spain.svg";
+  return "https://flagcdn.com/es.svg";
 }
 
 // Función para obtener el valor de España (total nacional)


### PR DESCRIPTION
## Summary
- Replace local Spain flag icon with CDN URL across components
- Lift Canary Islands inset on Spanish regions map for better visibility

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in src/utils/dataUtils.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899de0fbea88328a8a691b3ada3375c