### PR TITLE
feat: lazy load community flags

### DIFF
--- a/src/components/CommunityDistribution.tsx
+++ b/src/components/CommunityDistribution.tsx
@@ -165,12 +165,14 @@ const Flag: React.FC<FlagProps> = ({ code, width = 24, height = 18, className = 
   // Renderizar la imagen de la bandera si se encontró una URL
   if (flagUrl) {
     return (
-      <img 
-        src={flagUrl} 
-        alt={code} 
-        width={width} 
-        height={height} 
+      <img
+        src={flagUrl}
+        alt={code}
+        width={width}
+        height={height}
         className={`rounded border border-gray-300 shadow-sm ${extraStyles} ${className}`}
+        loading="lazy"
+        decoding="async"
       />
     );
   }

--- a/src/components/SectorDistribution.tsx
+++ b/src/components/SectorDistribution.tsx
@@ -107,12 +107,14 @@ const Flag: React.FC<FlagProps> = ({ code, width = 24, height = 18, className = 
   // Renderizar la imagen de la bandera si se encontró una URL
   if (flagUrl) {
     return (
-      <img 
-        src={flagUrl} 
-        alt={code} 
-        width={width} 
-        height={height} 
+      <img
+        src={flagUrl}
+        alt={code}
+        width={width}
+        height={height}
         className={`rounded ${extraStyles} ${className}`}
+        loading="lazy"
+        decoding="async"
       />
     );
   }


### PR DESCRIPTION
## Summary
- improve performance by lazy loading community flags
- decode flags asynchronously to render pages faster

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any. Specify a different type and other warnings)


------
https://chatgpt.com/codex/tasks/task_e_6899df1af64c8328806d78d7c536ae07