### PR TITLE
feat(researchers): add year filter and optimize metrics

### DIFF
--- a/src/components/ResearchersKeyMetrics.tsx
+++ b/src/components/ResearchersKeyMetrics.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import { TrendingUp, TrendingDown, Users, MapPin, Award, PieChart } from 'lucide-react';
 
 // Interfaces para los datos
@@ -86,15 +86,6 @@ const ResearchersKeyMetrics: React.FC<ResearchersKeyMetricsProps> = ({
   isLoading,
   isCommunityLoading
 }) => {
-  const [metrics, setMetrics] = useState<{
-    totalResearchers: number;
-    spainRanking: number;
-    totalCountries: number;
-    topCommunity: { name: string; value: number };
-    spainGrowth: number;
-    euPercentage: number;
-    topSector: { name: string; percentage: number };
-  } | null>(null);
 
   // Textos localizados
   const texts = {
@@ -183,26 +174,26 @@ const ResearchersKeyMetrics: React.FC<ResearchersKeyMetricsProps> = ({
     }
   };
 
-  useEffect(() => {
+  const metrics = useMemo(() => {
     if (isLoading || isCommunityLoading || !researchersData.length) {
-      return;
+      return null;
     }
 
     try {
       // 1. Calcular total de investigadores en España
-      const spainDataCurrent = researchersData.find(item => 
-        item.geo === 'ES' && 
-        item.TIME_PERIOD === selectedYear.toString() && 
+      const spainDataCurrent = researchersData.find(item =>
+        item.geo === 'ES' &&
+        item.TIME_PERIOD === selectedYear.toString() &&
         item.sectperf === 'TOTAL'
       );
-      
-      const totalResearchers = spainDataCurrent ? 
+
+      const totalResearchers = spainDataCurrent ?
         parseInt(spainDataCurrent.OBS_VALUE?.replace(',', '') || '0') : 0;
 
       // 2. Calcular ranking de España en Europa
       const europeanDataCurrent = researchersData
-        .filter(item => 
-          item.TIME_PERIOD === selectedYear.toString() && 
+        .filter(item =>
+          item.TIME_PERIOD === selectedYear.toString() &&
           item.sectperf === 'TOTAL' &&
           item.geo !== 'EU27_2020' &&
           item.OBS_VALUE
@@ -237,34 +228,34 @@ const ResearchersKeyMetrics: React.FC<ResearchersKeyMetricsProps> = ({
 
       // 4. Calcular crecimiento de España año sobre año
       const spainDataPrevious = researchersData.find(item =>
-        item.geo === 'ES' && 
-        item.TIME_PERIOD === (selectedYear - 1).toString() && 
+        item.geo === 'ES' &&
+        item.TIME_PERIOD === (selectedYear - 1).toString() &&
         item.sectperf === 'TOTAL'
       );
 
-      const previousValue = spainDataPrevious ? 
+      const previousValue = spainDataPrevious ?
         parseInt(spainDataPrevious.OBS_VALUE?.replace(',', '') || '0') : 0;
-      
-      const spainGrowth = previousValue > 0 ? 
+
+      const spainGrowth = previousValue > 0 ?
         ((totalResearchers - previousValue) / previousValue) * 100 : 0;
 
       // 5. Calcular porcentaje de España respecto al total UE
       const euDataCurrent = researchersData.find(item =>
-        item.geo === 'EU27_2020' && 
-        item.TIME_PERIOD === selectedYear.toString() && 
+        item.geo === 'EU27_2020' &&
+        item.TIME_PERIOD === selectedYear.toString() &&
         item.sectperf === 'TOTAL'
       );
 
-      const euTotal = euDataCurrent ? 
+      const euTotal = euDataCurrent ?
         parseInt(euDataCurrent.OBS_VALUE?.replace(',', '') || '0') : 0;
-      
+
       const euPercentage = euTotal > 0 ? (totalResearchers / euTotal) * 100 : 0;
 
       // 6. Encontrar sector principal en España
       const spainSectorData = researchersData
         .filter(item =>
-          item.geo === 'ES' && 
-          item.TIME_PERIOD === selectedYear.toString() && 
+          item.geo === 'ES' &&
+          item.TIME_PERIOD === selectedYear.toString() &&
           item.sectperf !== 'TOTAL' &&
           item.OBS_VALUE
         )
@@ -280,7 +271,7 @@ const ResearchersKeyMetrics: React.FC<ResearchersKeyMetricsProps> = ({
         percentage: totalResearchers > 0 ? (topSectorData.value / totalResearchers) * 100 : 0
       } : { name: t.noData, percentage: 0 };
 
-      setMetrics({
+      return {
         totalResearchers,
         spainRanking,
         totalCountries,
@@ -288,11 +279,11 @@ const ResearchersKeyMetrics: React.FC<ResearchersKeyMetricsProps> = ({
         spainGrowth,
         euPercentage,
         topSector
-      });
+      };
 
     } catch (error) {
       console.error('Error calculating metrics:', error);
-      setMetrics(null);
+      return null;
     }
   }, [researchersData, communityData, selectedYear, language, isLoading, isCommunityLoading]);
 

--- a/src/pages/Researchers/index.tsx
+++ b/src/pages/Researchers/index.tsx
@@ -61,6 +61,7 @@ const Researchers: React.FC<ResearchersProps> = (props) => {
   const [availableYears, setAvailableYears] = useState<number[]>([]);
   const [availableCommunityYears, setAvailableCommunityYears] = useState<number[]>([]);
   const [selectedYear, setSelectedYear] = useState<number>(2023);
+  const [selectedKeyYear, setSelectedKeyYear] = useState<number>(2023);
   const [selectedCommunityYear, setSelectedCommunityYear] = useState<number>(2021); // Año por defecto para comunidades
   
   // Estados separados para cada sección
@@ -114,6 +115,7 @@ const Researchers: React.FC<ResearchersProps> = (props) => {
         // Establecer el año más reciente como predeterminado
         if (years.length > 0) {
           setSelectedYear(years[0]);
+          setSelectedKeyYear(years[0]);
         }
 
         setError(null);
@@ -199,6 +201,12 @@ const Researchers: React.FC<ResearchersProps> = (props) => {
 
     loadCommunityData();
   }, [language]);
+
+  useEffect(() => {
+    if (availableYears.length > 0 && !availableYears.includes(selectedKeyYear)) {
+      setSelectedKeyYear(availableYears[0]);
+    }
+  }, [availableYears, selectedKeyYear]);
 
   // Función para mapear el valor del sector al código utilizado en los datos
   const mapSectorToCode = (sector: string): string => {
@@ -373,12 +381,31 @@ const Researchers: React.FC<ResearchersProps> = (props) => {
       {/* Sección 1: Key Metrics */}
       <div className="mb-12 mt-[-15px]">
         <SectionTitle title={language === 'es' ? "Métricas clave" : "Key Metrics"} />
+        <div className="mb-4 flex items-center">
+          <div className="flex items-center">
+            <svg className="w-5 h-5 text-gray-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+            </svg>
+            <h2 className="text-gray-700 font-medium text-sm">
+              {language === 'es' ? 'Información para el año' : 'Information for year'}
+            </h2>
+            <select
+              value={selectedKeyYear}
+              onChange={(e) => setSelectedKeyYear(parseInt(e.target.value))}
+              className="ml-2 border border-gray-300 rounded px-2 py-0.5 bg-white text-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300"
+            >
+              {availableYears.map(year => (
+                <option key={year} value={year}>{year}</option>
+              ))}
+            </select>
+          </div>
+        </div>
         <div className="mb-8">
           <SubsectionTitle title={language === 'es' ? "Indicadores de investigación" : "Research Indicators"} />
           <ResearchersKeyMetrics
             researchersData={researchersData}
             communityData={researchersCommunityData}
-            selectedYear={selectedYear}
+            selectedYear={selectedKeyYear}
             language={language}
             isLoading={isLoading}
             isCommunityLoading={isCommunityLoading}


### PR DESCRIPTION
## Summary
- add year selector for researchers key metrics
- memoize calculation of research metrics to reduce load time

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899e2cddea483288147964a5e6d138c