### PR TITLE
Show full sector names in community sector evolution tooltip

### DIFF
--- a/src/components/ResearchersCommunitiesBySectorChart.tsx
+++ b/src/components/ResearchersCommunitiesBySectorChart.tsx
@@ -340,7 +340,7 @@ const ResearchersCommunitiesBySectorChart: React.FC<ResearchersCommunitiesBySect
                     className="w-3 h-3 rounded-full mr-3 shadow-sm ring-1 ring-gray-200" 
                     style={{ backgroundColor: entry.color }}
                   ></div>
-                  <span className="text-sm font-medium text-gray-700 truncate">
+                  <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">
                     {sectorName}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- Ensure sector name is never truncated in the "Evolución sectorial por comunidades autónomas" tooltip

## Testing
- `npm run lint` (fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899e2d6774883288caac42b29272136