### PR TITLE
Remove grid from patents timeline charts

### DIFF
--- a/src/components/PatentsEuropeanTimelineChart.tsx
+++ b/src/components/PatentsEuropeanTimelineChart.tsx
@@ -4,7 +4,6 @@ import {
   Line,
   XAxis,
   YAxis,
-  CartesianGrid,
   Tooltip,
   ResponsiveContainer,
   Customized
@@ -647,9 +646,8 @@ const PatentsEuropeanTimelineChart: React.FC<PatentsEuropeanTimelineChartProps> 
             data={timeSeriesData}
             margin={{ top: 20, right: 60, left: 20, bottom: 10 }}
           >
-            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-            <XAxis 
-              dataKey="year" 
+            <XAxis
+              dataKey="year"
               tick={{ fill: '#4b5563', fontSize: 10 }}
               tickLine={{ stroke: '#9ca3af' }}
               axisLine={{ stroke: '#e5e7eb' }}

--- a/src/components/PatentsTimelineChart.tsx
+++ b/src/components/PatentsTimelineChart.tsx
@@ -4,7 +4,6 @@ import {
   Line,
   XAxis,
   YAxis,
-  CartesianGrid,
   Tooltip,
   ResponsiveContainer,
   Customized
@@ -703,9 +702,8 @@ const PatentsTimelineChart: React.FC<PatentsTimelineChartProps> = ({
             data={timeSeriesData}
             margin={{ top: 20, right: 60, left: 20, bottom: 10 }}
           >
-            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-            <XAxis 
-              dataKey="year" 
+            <XAxis
+              dataKey="year"
               tick={{ fill: '#4b5563', fontSize: 10 }}
               tickLine={{ stroke: '#9ca3af' }}
               axisLine={{ stroke: '#e5e7eb' }}


### PR DESCRIPTION
## Summary
- remove CartesianGrid from patents timeline components to hide chart grid

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint src/components/PatentsEuropeanTimelineChart.tsx src/components/PatentsTimelineChart.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6899e98974648328b063153acc0376a9