### PR TITLE
Align Canary Islands in R&D map

### DIFF
--- a/src/components/SpanishRegionsMap.tsx
+++ b/src/components/SpanishRegionsMap.tsx
@@ -985,7 +985,10 @@ const SpanishRegionsMap: React.FC<SpanishRegionsMapProps> = ({
       const projectionCanarias = d3.geoMercator()
         .center([-15.5, 28.2])
         .scale(canariasScale) // Aumentado para que las islas se vean más grandes
-        .translate([containerWidth * 0.14, containerHeight * 0.80]); // Alinear posición con el mapa de investigadores
+        .translate([
+          containerWidth * 0.14,
+          containerHeight * 0.68,
+        ]); // Centrar las islas dentro del nuevo recuadro
       
       // Crear proyección específica para Ceuta y Melilla (compartirán recuadro)
       const projectionCeuta = d3.geoMercator()


### PR DESCRIPTION
## Summary
- Center the Canary Islands geometry within the raised dotted inset on the R&D investment map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea1dca408328b1f2c0045d14299e