### PR TITLE
feat: unify sector evolution tooltip design

### DIFF
--- a/src/components/SectorEvolutionChart.tsx
+++ b/src/components/SectorEvolutionChart.tsx
@@ -354,16 +354,20 @@ const SectorEvolutionChart: React.FC<SectorEvolutionChartProps> = ({
   };
   
   // Función para calcular el cambio año a año (YoY)
-  const calculateYoY = (currentValue: number | null, sectorId: string, currentYearIndex: number) => {
+  const calculateYoY = (
+    currentValue: number | null,
+    sectorId: string,
+    currentYearIndex: number
+  ): number | null => {
     if (currentValue === null || currentYearIndex <= 0) return null;
-    
+
     const previousYearData = timeSeriesData[currentYearIndex - 1];
     const previousValue = previousYearData?.[sectorId] as number | null;
-    
+
     if (previousValue === null || previousValue === 0) return null;
-    
+
     const percentChange = ((currentValue - previousValue) / previousValue) * 100;
-    return percentChange.toFixed(1);
+    return percentChange;
   };
   
   // Componente de tooltip personalizado para la gráfica
@@ -397,47 +401,50 @@ const SectorEvolutionChart: React.FC<SectorEvolutionChartProps> = ({
         });
       
       return (
-      <div className="bg-white/95 backdrop-blur-sm p-4 border border-gray-200/60 shadow-xl rounded-xl max-w-xs">
-        <div className="border-b border-gray-100 pb-2 mb-3">
-          <p className="text-sm font-semibold text-gray-800 flex items-center">
-            <span className="w-2 h-2 bg-blue-500 rounded-full mr-2"></span>
-            {`${selectedCommunity.localName} (${label})`}
-          </p>
-        </div>
+        <div className="bg-white/95 backdrop-blur-sm p-4 border border-gray-200/60 shadow-xl rounded-xl max-w-xs">
+          <div className="border-b border-gray-100 pb-2 mb-3">
+            <p className="text-sm font-semibold text-gray-800 flex items-center">
+              <span className="w-2 h-2 bg-blue-500 rounded-full mr-2"></span>
+              {`${language === 'es' ? selectedCommunity.localName : selectedCommunity.name} (${label})`}
+            </p>
+          </div>
           <div className="space-y-2.5">
             {sortedPayload.map((entry, index) => {
               // Traducir el nombre del sector
               const sectorName = t[entry.dataKey as keyof typeof t] || entry.name;
-              
+
               // Calcular el cambio YoY
               const yoyChange = calculateYoY(entry.value, entry.dataKey, yearIndex);
-            const yoyText = yoyChange !== null ? 
-              `(${parseFloat(yoyChange) >= 0 ? '+' : ''}${yoyChange}%)` : '';
-              
+              const yoyText = yoyChange !== null
+                ? `(${yoyChange >= 0 ? '+' : ''}${yoyChange.toFixed(1)}%)`
+                : '';
+
               return (
-              <div key={index} className="flex items-center justify-between py-1">
-                <div className="flex items-center flex-1 min-w-0">
-                      <div 
-                    className="w-3 h-3 rounded-full mr-3 shadow-sm ring-1 ring-gray-200" 
-                        style={{ backgroundColor: entry.color }}
-                      ></div>
-                  <span className="text-sm font-medium text-gray-700 truncate">
-                    {sectorName}
-                  </span>
-                    </div>
-                <div className="flex items-center ml-3">
-                  <span className="text-sm font-bold text-gray-900">
-                        {entry.value.toFixed(2)}%
+                <div key={index} className="flex items-center justify-between py-1">
+                  <div className="flex items-center flex-1 min-w-0">
+                    <div
+                      className="w-3 h-3 rounded-full mr-3 shadow-sm ring-1 ring-gray-200"
+                      style={{ backgroundColor: entry.color }}
+                    ></div>
+                    <span className="text-sm font-medium text-gray-700 whitespace-normal break-words">
+                      {sectorName}
+                    </span>
+                  </div>
+                  <div className="flex items-center ml-3">
+                    <span className="text-sm font-bold text-gray-900">
+                      {entry.value.toFixed(2)}%
+                    </span>
+                    {yoyChange !== null && (
+                      <span
+                        className={`ml-2 text-xs font-medium px-1.5 py-0.5 rounded-md ${
+                          yoyChange >= 0
+                            ? 'text-emerald-700 bg-emerald-50'
+                            : 'text-red-700 bg-red-50'
+                        }`}
+                      >
+                        {yoyText}
                       </span>
-                  {yoyChange !== null && (
-                    <span className={`ml-2 text-xs font-medium px-1.5 py-0.5 rounded-md ${
-                      parseFloat(yoyChange) >= 0 
-                        ? 'text-emerald-700 bg-emerald-50' 
-                        : 'text-red-700 bg-red-50'
-                    }`}>
-                      {yoyText}
-                        </span>
-                      )}
+                    )}
                   </div>
                 </div>
               );


### PR DESCRIPTION
## Summary
- match investment sector evolution tooltip with researchers version
- ensure multilingual community names and proper YoY formatting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Definition for rule '@typescript-eslint/ban-types' was not found, and 27 warnings)

------
https://chatgpt.com/codex/tasks/task_e_689a0138bc948328bc8990a869ec4805