### PR TITLE
feat: enlarge patents country map

### DIFF
--- a/src/components/PatentsEuropeanMap.tsx
+++ b/src/components/PatentsEuropeanMap.tsx
@@ -1796,7 +1796,7 @@ const PatentsEuropeanMap: React.FC<PatentsEuropeanMapProps> = ({
 
 
   return (
-    <div className="relative w-full" style={{ height: '620px' }}>
+    <div className="relative w-full max-w-5xl mx-auto" style={{ height: '800px' }}>
       <div className="mb-2 text-center">
         <h3 className="text-sm font-semibold text-gray-800">
           {getMapTitle()} · {selectedYear}
@@ -1807,7 +1807,7 @@ const PatentsEuropeanMap: React.FC<PatentsEuropeanMapProps> = ({
         </div>
       </div>
       
-      <div className="relative" style={{ height: '540px', border: '1px solid #f0f0f0', borderRadius: '8px', overflow: 'hidden' }}>
+      <div className="relative mx-auto" style={{ height: '720px', border: '1px solid #f0f0f0', borderRadius: '8px', overflow: 'hidden' }}>
         {isLoading ? (
           <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-80">
             <div className="text-center">

--- a/src/pages/Patents/index.tsx
+++ b/src/pages/Patents/index.tsx
@@ -409,7 +409,7 @@ const Patents: React.FC<PatentsProps> = (props) => {
               <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 sm:gap-6 lg:gap-8 mb-8">
                 {/* Mapa de Europa */}
                 <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 border border-gray-100 order-2 xl:order-1">
-                  <div className="h-[400px] sm:h-[500px] lg:h-[660px]">
+                  <div className="h-[600px] sm:h-[750px] lg:h-[900px] flex items-center justify-center">
                     <PatentsEuropeanMap
                       data={patentsData}
                       selectedYear={selectedYear}


### PR DESCRIPTION
## Summary
- enlarge Patents by Country map and center display
- center map container in patents page with more height

## Testing
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689a019bf4bc8328970459ee36566b43