### PR TITLE
Improve i18n initialization and map tooltip translations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Researchers from './pages/Researchers'; // Importar el componente de la p
 import Patents from './pages/Patents'; // Importar el componente de la página Patents
 import SourcesSection from './components/SourcesSection';
 import PWAInstallPrompt from './components/PWAInstallPrompt';
+import i18n from './i18n/i18n';
 
 // Definir tipos
 type TabType = 'overview' | 'investment' | 'researchers' | 'patents' | 'sources';
@@ -13,7 +14,7 @@ type Language = 'es' | 'en';
 
 const App: React.FC = () => {
   const [activeTab, setActiveTab] = useState<TabType>('overview'); // Cambiando a 'overview' para mostrar primero la visión general
-  const [language, setLanguage] = useState<Language>('es');
+  const [language, setLanguage] = useState<Language>((i18n.language as Language) || 'es');
   const [showLangDropdown, setShowLangDropdown] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -67,54 +68,14 @@ const App: React.FC = () => {
     setIsMobileMenuOpen(false);
   }, [activeTab]); // Ejecutar este efecto cuando cambie activeTab
 
-  // Usar useEffect para detectar cambios de idioma y mantener la experiencia fluida
-  React.useEffect(() => {
-    // No hacer nada en el primer renderizado
-    // Este efecto solo restaurará la posición cuando cambie el idioma
-  }, [language]);
-  
   const toggleLanguage = () => {
-    // Capturar dimensiones y posición exacta antes del cambio
-    const contentElement = contentRef.current;
-    let scrollInfo = null;
-    
-    if (contentElement) {
-      // Guardar información de scroll y dimensiones relativas
-      const rect = contentElement.getBoundingClientRect();
-      const visibleRatio = Math.abs(rect.top) / contentElement.scrollHeight;
-      scrollInfo = {
-        element: contentElement,
-        visibleRatio,
-        visibleTop: rect.top,
-        // Capturar posición exacta de elementos visibles para referencia
-        elementAtViewport: document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2)
-      };
-    }
-    
-    // Preparar la transición visual suave
-    document.body.style.opacity = '0.98';
-    document.body.style.transition = 'opacity 0.15s ease';
-    
-    // Cambiar el idioma
-    setLanguage(prev => prev === 'es' ? 'en' : 'es');
+    setLanguage(prev => (prev === 'es' ? 'en' : 'es'));
     setShowLangDropdown(false);
-    
-    // Restaurar la posición después del renderizado
-    setTimeout(() => {
-      // Primero hacer visible el contenido nuevamente
-      document.body.style.opacity = '1';
-      
-      // Intentar restaurar posición exacta
-      if (scrollInfo && scrollInfo.element) {
-        // Calcular la nueva posición basándose en la relación de visibilidad anterior
-        const targetScrollTop = scrollInfo.element.scrollHeight * scrollInfo.visibleRatio;
-        window.scrollTo({
-          top: targetScrollTop,
-          behavior: 'auto' // Usar 'auto' para evitar animación adicional
-        });
-      }
-    }, 50); // Un pequeño retraso para permitir que React complete el renderizado
   };
+
+  useEffect(() => {
+    i18n.changeLanguage(language);
+  }, [language]);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100 flex flex-col w-full">

--- a/src/components/ResearchersSpanishRegionsMap.tsx
+++ b/src/components/ResearchersSpanishRegionsMap.tsx
@@ -88,7 +88,9 @@ const mapTexts = {
     tooltipTitle: 'Investigadores',
     researchers: 'Investigadores',
     researchersPerThousand: 'Investigadores por mil habitantes',
-    noData: 'Sin datos'
+    noData: 'Sin datos',
+    noResearchers: 'Sin investigadores',
+    of: 'de'
   },
   'en': {
     loading: 'Loading map...',
@@ -100,7 +102,9 @@ const mapTexts = {
     tooltipTitle: 'Researchers',
     researchers: 'Researchers',
     researchersPerThousand: 'Researchers per thousand inhabitants',
-    noData: 'No data'
+    noData: 'No data',
+    noResearchers: 'No researchers',
+    of: 'of'
   }
 };
 
@@ -1589,7 +1593,7 @@ const ResearchersSpanishRegionsMap: React.FC<ResearchersSpanishRegionsMapProps> 
                         <polyline points="12 6 12 12 16 14"></polyline>
                 </svg>
               </div>
-                    <div class="text-gray-500 font-medium">${language === 'es' ? 'Sin datos' : 'No data'}</div>
+                    <div class="text-gray-500 font-medium">${mapTexts[language].noData}</div>
               </div>
             </div>
           `;
@@ -1617,7 +1621,7 @@ const ResearchersSpanishRegionsMap: React.FC<ResearchersSpanishRegionsMapProps> 
               </div>
               <div class="flex items-center">
                 <span class="text-xl font-bold text-orange-500">0</span>
-                <span class="text-xs ml-2 text-orange-500">${language === 'es' ? 'Sin investigadores' : 'No researchers'}</span>
+                <span class="text-xs ml-2 text-orange-500">${mapTexts[language].noResearchers}</span>
                       </div>
                     </div>
               </div>
@@ -1667,7 +1671,7 @@ const ResearchersSpanishRegionsMap: React.FC<ResearchersSpanishRegionsMapProps> 
                   <line x1="12" y1="8" x2="12" y2="12"></line>
                   <line x1="12" y1="16" x2="12.01" y2="16"></line>
                 </svg>
-                <span>Sin datos vs ${selectedYear - 1}</span>
+                <span>${mapTexts[language].noData} vs ${selectedYear - 1}</span>
               </div>
             `;
           }
@@ -1683,9 +1687,9 @@ const ResearchersSpanishRegionsMap: React.FC<ResearchersSpanishRegionsMapProps> 
                     <circle cx="12" cy="8" r="6" />
                     <path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11" />
                   </svg>
-                  <span class="font-medium">Rank </span>
+                  <span class="font-medium">${mapTexts[language].rankLabel} </span>
                   <span class="font-bold text-lg mx-1">${ranking.rank}</span>
-                  <span class="text-gray-600">${language === 'es' ? `de ${ranking.total}` : `of ${ranking.total}`}</span>
+                  <span class="text-gray-600">${mapTexts[language].of} ${ranking.total}</span>
                 </div>
               </div>
             `;
@@ -2254,6 +2258,7 @@ const ResearchersSpanishRegionsMap: React.FC<ResearchersSpanishRegionsMapProps> 
             }}
           >
             <svg ref={svgRef} className="w-full h-full"></svg>
+            <div className="text-xs text-gray-600 text-center mt-2">{mapTexts[language].legend}</div>
           </div>
         </>
       )}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -29,21 +29,26 @@
     "total": "Total Investment",
     "year": "Year",
     "percentage": "Percentage",
-    "overview": "R&D Investment Overview"
+    "overview": "R&D Investment Overview",
+    "description": "Analysis of financial effort in R&D as a percentage of GDP, sectoral distribution and comparative temporal evolution."
   },
   "researchers": {
     "title": "Number of Researchers",
     "public": "Public Sector",
     "private": "Private Sector",
     "total": "Total Researchers",
-    "year": "Year"
+    "year": "Year",
+    "description": "Human capital dedicated to research and development by activity sectors, with territorial analysis and temporal evolution. Data in full-time equivalent (FTE).",
+    "legend": "Researchers (FTE)",
+    "tooltipTitle": "Researchers"
   },
   "patents": {
     "title": "Number of Patents",
     "public": "Public Sector",
     "private": "Private Sector",
     "total": "Total Patents",
-    "year": "Year"
+    "year": "Year",
+    "description": "Analysis of patent applications filed with the European Patent Office (EPO) as an indicator of territorial innovation capacity, with regional and sectoral comparative data."
   },
   "common": {
     "canaryIslands": "Canary Islands",
@@ -65,4 +70,4 @@
     "basqueCountry": "Basque Country",
     "maxSelectionsReached": "Maximum of {{count}} selections"
   }
-} 
+}

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -29,21 +29,26 @@
     "total": "Inversión Total",
     "year": "Año",
     "percentage": "Porcentaje",
-    "overview": "Resumen de Inversión en I+D"
+    "overview": "Resumen de Inversión en I+D",
+    "description": "Análisis del esfuerzo financiero en I+D como porcentaje del PIB, distribución sectorial y evolución temporal comparada."
   },
   "researchers": {
     "title": "Número de Investigadores",
     "public": "Sector Público",
     "private": "Sector Privado",
     "total": "Total Investigadores",
-    "year": "Año"
+    "year": "Año",
+    "description": "Capital humano dedicado a la investigación y desarrollo por sectores de actividad, con análisis territorial y evolución temporal. Datos en equivalencia a tiempo completo (ETC).",
+    "legend": "Investigadores (EJC)",
+    "tooltipTitle": "Investigadores"
   },
   "patents": {
     "title": "Número de Patentes",
     "public": "Sector Público",
     "private": "Sector Privado",
     "total": "Total Patentes",
-    "year": "Año"
+    "year": "Año",
+    "description": "Análisis de las solicitudes de patentes presentadas ante la Oficina Europea de Patentes (EPO) como indicador de la capacidad innovadora del territorio, con datos comparativos regionales y sectoriales."
   },
   "common": {
     "canaryIslands": "Islas Canarias",
@@ -65,4 +70,4 @@
     "basqueCountry": "País Vasco",
     "maxSelectionsReached": "Máximo de {{count}} selecciones"
   }
-} 
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
 import { LanguageProvider } from './contexts/LanguageContext'
+import './i18n/i18n'
 
 console.log('Iniciando aplicación...')
 


### PR DESCRIPTION
## Summary
- initialize i18next on app start
- make language switch instantaneous
- localize researcher map tooltip and legend strings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a04d877c483289c1b19e5c08c0d5a