### PR TITLE
Fix nested container styling on patents charts

### DIFF
--- a/src/pages/Patents/index.tsx
+++ b/src/pages/Patents/index.tsx
@@ -333,7 +333,7 @@ const Patents: React.FC<PatentsProps> = (props) => {
               </div>
             </div>
           ) : (
-            <div className="bg-white rounded-lg w-full">
+            <div className="w-full">
               {/* Filtros */}
               <div className="bg-blue-50 p-3 sm:p-4 rounded-md border border-blue-100 mb-6">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
@@ -564,7 +564,7 @@ const Patents: React.FC<PatentsProps> = (props) => {
           <SubsectionTitle title={t.geographicalDistribution} />
           
           {regionalData.length > 0 ? (
-            <div className="bg-white rounded-lg w-full">
+            <div className="w-full">
               {/* Filtros para la sección regional */}
               <div className="bg-blue-50 p-3 rounded-md border border-blue-100 mb-4">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">


### PR DESCRIPTION
## Summary
- remove extra white container wrappers around patents map and regional sections to avoid nested boxes

## Testing
- `npm run lint` *(fails: @typescript-eslint plugin rule definition not found in unrelated files)*
- `npx eslint src/pages/Patents/index.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689a35991648832885969c0239049850