### PR TITLE
Adjust patent chart container sizing

### DIFF
--- a/src/components/PatentsEuropeanMap.tsx
+++ b/src/components/PatentsEuropeanMap.tsx
@@ -1809,7 +1809,7 @@ const PatentsEuropeanMap: React.FC<PatentsEuropeanMapProps> = ({
       
       <div
         className="relative mx-auto"
-        style={{ height: '450px', border: '1px solid #f0f0f0', borderRadius: '8px', overflow: 'hidden' }}
+        style={{ border: '1px solid #f0f0f0', borderRadius: '8px', overflow: 'hidden', aspectRatio: '1000 / 700' }}
       >
         {isLoading ? (
           <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-80">

--- a/src/components/PatentsRankingChart.tsx
+++ b/src/components/PatentsRankingChart.tsx
@@ -1027,7 +1027,7 @@ function getCountryFlagUrl(countryCode: string): string {
   const chartData: ChartDataResult = prepareChartData();
   
   // Altura dinámica para el gráfico en función del número de países
-  const chartHeight = Math.max(400, chartData.labels.length * 35);
+  const chartHeight = Math.max(50, chartData.labels.length * 35);
 
   // Determinar si hay datos para mostrar (con filtro de coop_ptn = 'APPL')
   const hasData = data.filter(item => 
@@ -1037,7 +1037,7 @@ function getCountryFlagUrl(countryCode: string): string {
   
   // Estilos para el contenedor con scroll
   const scrollContainerStyle: React.CSSProperties = {
-    height: '360px',
+    maxHeight: '360px',
     overflowY: 'auto',
     border: '1px solid #f0f0f0',
     borderRadius: '8px',
@@ -1082,8 +1082,8 @@ function getCountryFlagUrl(countryCode: string): string {
   }, []);
 
   if (!hasData) {
-  return (
-      <div className="flex justify-center items-center bg-gray-50 rounded-lg border border-gray-200" style={{ height: '450px' }}>
+    return (
+      <div className="flex justify-center items-center bg-gray-50 rounded-lg border border-gray-200 py-10">
         <div className="text-center text-gray-500">
           <svg className="w-12 h-12 mx-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -1095,7 +1095,7 @@ function getCountryFlagUrl(countryCode: string): string {
   }
 
   return (
-    <div className="relative" style={{ height: '450px' }} ref={containerRef}>
+    <div className="relative" ref={containerRef}>
       <div className="mb-2 text-center">
         <h3 className="text-sm font-semibold text-gray-800">
           {t.title} · {selectedYear}

--- a/src/pages/Patents/index.tsx
+++ b/src/pages/Patents/index.tsx
@@ -408,7 +408,7 @@ const Patents: React.FC<PatentsProps> = (props) => {
               {/* Primera fila: Mapa y Gráfica - Mejorado para móvil */}
               <div className="flex flex-col lg:flex-row gap-6 mb-8">
                 {/* Mapa de Europa */}
-                <div className="w-full lg:w-1/2 min-h-[450px] bg-white border border-gray-200 rounded-lg shadow-sm p-4 order-2 lg:order-1">
+                <div className="w-full lg:w-1/2 bg-white border border-gray-200 rounded-lg shadow-sm p-4 order-2 lg:order-1">
                   <PatentsEuropeanMap
                     data={patentsData}
                     selectedYear={selectedYear}
@@ -419,7 +419,7 @@ const Patents: React.FC<PatentsProps> = (props) => {
                 </div>
 
                 {/* Ranking de países */}
-                <div className="w-full lg:w-1/2 min-h-[450px] bg-white border border-gray-200 rounded-lg shadow-sm p-4 order-1 lg:order-2">
+                <div className="w-full lg:w-1/2 bg-white border border-gray-200 rounded-lg shadow-sm p-4 order-1 lg:order-2">
                   {patentsData.length > 0 ? (
                     <div className="h-full overflow-hidden">
                       <PatentsRankingChart


### PR DESCRIPTION
## Summary
- let patent map use aspect-ratio sizing instead of a fixed 450px height
- remove fixed height from patent ranking chart and adapt container to data
- drop hardcoded min height on Patents page containers

## Testing
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689a38ad28b08328b2835ef5b1fe12e8