### PR TITLE
Fix patent chart container sizing

### DIFF
--- a/src/components/PatentsEuropeanMap.tsx
+++ b/src/components/PatentsEuropeanMap.tsx
@@ -1796,7 +1796,7 @@ const PatentsEuropeanMap: React.FC<PatentsEuropeanMapProps> = ({
 
 
   return (
-    <div className="relative w-full max-w-5xl mx-auto" style={{ height: '800px' }}>
+    <div className="relative w-full max-w-5xl mx-auto">
       <div className="mb-2 text-center">
         <h3 className="text-sm font-semibold text-gray-800">
           {getMapTitle()} · {selectedYear}

--- a/src/pages/Patents/index.tsx
+++ b/src/pages/Patents/index.tsx
@@ -421,7 +421,7 @@ const Patents: React.FC<PatentsProps> = (props) => {
                 {/* Ranking de países */}
                 <div className="w-full lg:w-1/2 bg-white border border-gray-200 rounded-lg shadow-sm p-4 order-1 lg:order-2">
                   {patentsData.length > 0 ? (
-                    <div className="h-full overflow-hidden">
+                    <div className="overflow-hidden">
                       <PatentsRankingChart
                         data={patentsData}
                         selectedYear={selectedYear}
@@ -431,7 +431,7 @@ const Patents: React.FC<PatentsProps> = (props) => {
                       />
                     </div>
                   ) : (
-                    <div className="flex justify-center items-center h-full">
+                    <div className="flex justify-center items-center">
                       {isLoading ? (
                         <div className="flex flex-col items-center">
                           <div className="animate-spin rounded-full h-8 w-8 sm:h-12 sm:w-12 border-b-2 border-blue-500"></div>


### PR DESCRIPTION
## Summary
- remove fixed height wrapper around European patents map to match map dimensions
- avoid stretching patent ranking chart container beyond its content

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/ban-types' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3b0dfb2483288522b33bde964abf