### PR TITLE
fix: remove redundant web manifest link

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,9 @@
   <link rel="apple-touch-icon" href="/pwa-icon-192.svg" sizes="192x192">
   <link rel="apple-touch-icon" href="/pwa-icon-512.svg" sizes="512x512">
   <link rel="shortcut icon" href="/research-icon.svg" type="image/svg+xml">
-  <link rel="manifest" href="/manifest.json">
   
   <!-- Web App Manifest -->
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="manifest" href="/manifest.json">
   
   <!-- Critical CSS for faster loading -->
   <style>


### PR DESCRIPTION
## Summary
- remove redundant web manifest link that referenced missing `site.webmanifest`

## Testing
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a3b560f58832897c6113105e483e9