### PR TITLE
chore: improve cross-browser build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,10 @@
     "vite": "^6.3.1",
     "vite-plugin-pwa": "^1.0.0",
     "workbox-window": "^7.3.0"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "not IE 11",
+    "maintained node versions"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,5 +68,12 @@ export default defineConfig({
     },
   },
   // Modo de desarrollo con más mensajes de depuración
-  logLevel: 'info'
+  logLevel: 'info',
+  // Salida compatible con navegadores modernos y algunos más antiguos
+  build: {
+    target: 'es2018'
+  },
+  esbuild: {
+    target: 'es2018'
+  }
 })


### PR DESCRIPTION
## Summary
- target ES2018 in Vite build for wider browser support
- add browserslist config

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/ban-types' was not found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a41036708832890ee402c09e5d53d