### PR TITLE
chore: target older browsers

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,11 +79,11 @@ export default defineConfig({
   },
   // Modo de desarrollo con más mensajes de depuración
   logLevel: 'info',
-  // Salida compatible con navegadores modernos y algunos más antiguos
+  // Salida compatible con un rango más amplio de navegadores
   build: {
-    target: 'es2018'
+    target: 'es2015'
   },
   esbuild: {
-    target: 'es2018'
+    target: 'es2015'
   }
 })


### PR DESCRIPTION
## Summary
- broaden build targets to better support older browsers

## Testing
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/ban-types' was not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a4c7d6e4c8328bfa0f412f9e832c7