### PR TITLE
Configure Vercel rewrites and refine Vite build settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,24 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-XSS-Protection", "value": "1; mode=block" }
+      ]
+    },
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       }
     })
   ],
+  base: './',
   publicDir: 'public',
   server: {
     port: 5173,
@@ -58,13 +59,17 @@ export default defineConfig({
     open: true, // Abre el navegador automáticamente
     headers: {
       'X-Content-Type-Options': 'nosniff',
-      'Cache-Control': 'public, max-age=3600'
+      'Cache-Control': 'public, max-age=3600',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Cross-Origin-Opener-Policy': 'same-origin'
     }
   },
   preview: {
     headers: {
       'X-Content-Type-Options': 'nosniff',
-      'Cache-Control': 'public, max-age=3600'
+      'Cache-Control': 'public, max-age=3600',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Cross-Origin-Opener-Policy': 'same-origin'
     }
   },
   // Incluye una configuración específica para que Vite sirva correctamente los archivos CSV
@@ -81,9 +86,16 @@ export default defineConfig({
   logLevel: 'info',
   // Salida compatible con navegadores modernos y algunos más antiguos
   build: {
-    target: 'es2018'
+    target: 'es2015',
+    outDir: 'dist',
+    assetsDir: 'assets',
+    rollupOptions: {
+      output: {
+        manualChunks: undefined
+      }
+    }
   },
   esbuild: {
-    target: 'es2018'
+    target: 'es2015'
   }
 })


### PR DESCRIPTION
## Summary
- add `vercel.json` with rewrites and security/caching headers for Vercel deployment
- tune Vite config: set base path, add cross-origin isolation headers, and adjust build targets and output directories

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a4ee9dfa08328b5b5d7df608c141f