### PR TITLE
Remove Canary Islands comparison from researcher country charts

### DIFF
--- a/src/components/ResearcherRankingChart.tsx
+++ b/src/components/ResearcherRankingChart.tsx
@@ -86,26 +86,12 @@ interface ResearchersData {
   [key: string]: string | undefined;
 }
 
-// Datos de comunidades autónomas
-interface ResearchersCommunityData {
-  TERRITORIO: string;
-  TERRITORIO_CODE: string;
-  TIME_PERIOD: string;
-  SECTOR_EJECUCION: string;
-  SECTOR_EJECUCION_CODE: string;
-  SEXO: string;
-  SEXO_CODE: string;
-  OBS_VALUE: string;
-  [key: string]: string;
-}
-
 // Interfaz para las propiedades del componente
 interface ResearcherRankingChartProps {
   data: ResearchersData[];
   selectedYear: number;
   language: 'es' | 'en';
   selectedSector?: string;
-  autonomousCommunitiesData?: ResearchersCommunityData[];
 }
 
 // Colores para la gráfica
@@ -236,8 +222,7 @@ const ResearcherRankingChart: React.FC<ResearcherRankingChartProps> = ({
   data,
   selectedYear,
   language,
-  selectedSector = 'total',
-  autonomousCommunitiesData = []
+  selectedSector = 'total'
 }) => {
   const chartRef = useRef(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -829,10 +814,9 @@ const ResearcherRankingChart: React.FC<ResearcherRankingChartProps> = ({
             `;
           }
           
-          // Preparar comparaciones con UE, España y Canarias
+          // Preparar comparaciones con UE y España
           const euItem = chartData.sortedItems.find(item => item.code === 'EU27_2020');
           const spainItem = chartData.sortedItems.find(item => item.code === 'ES');
-          const canariasValue = getCanariasValue(autonomousCommunitiesData, selectedYear, selectedSector);
           let comparisonsHtml = '';
           
                       // Comparativa con la UE (media) - usar el mismo cálculo que en el mapa
@@ -860,41 +844,15 @@ const ResearcherRankingChart: React.FC<ResearcherRankingChartProps> = ({
             const percentDiff = (difference / spainItem.value) * 100;
             const formattedDiff = percentDiff.toFixed(1);
             const isPositive = difference > 0;
-            
+
             comparisonsHtml += `
               <div class="flex justify-between items-center text-xs">
-                <span class="text-gray-600 inline-block w-44">${language === 'es' ? 
-                  `vs España (${formatValue(Math.round(spainItem.value))}):` : 
+                <span class="text-gray-600 inline-block w-44">${language === 'es' ?
+                  `vs España (${formatValue(Math.round(spainItem.value))}):` :
                   `vs Spain (${formatValue(Math.round(spainItem.value))}):`}</span>
                 <span class="font-medium ${isPositive ? 'text-green-600' : 'text-red-600'}">${isPositive ? '+' : ''}${formattedDiff}%</span>
               </div>
             `;
-          }
-
-          // Comparativa con Canarias
-          if (!chartItem.isSupranational) {
-            if (canariasValue !== null) {
-              const difference = value - canariasValue;
-              const percentDiff = (difference / canariasValue) * 100;
-              const formattedDiff = percentDiff.toFixed(1);
-              const isPositive = difference > 0;
-
-              comparisonsHtml += `
-                <div class="flex justify-between items-center text-xs">
-                  <span class="text-gray-600 inline-block w-44">${language === 'es' ?
-                    `vs Islas Canarias (${formatValue(Math.round(canariasValue))}):` :
-                    `vs Canary Islands (${formatValue(Math.round(canariasValue))}):`}</span>
-                  <span class="font-medium ${isPositive ? 'text-green-600' : 'text-red-600'}">${isPositive ? '+' : ''}${formattedDiff}%</span>
-                </div>
-              `;
-            } else {
-              comparisonsHtml += `
-                <div class="flex justify-between items-center text-xs">
-                  <span class="text-gray-600 inline-block w-44">${language === 'es' ? 'vs Islas Canarias:' : 'vs Canary Islands:'}</span>
-                  <span class="font-medium text-gray-400">--</span>
-                </div>
-              `;
-            }
           }
           
           // Descripción de flag si existe
@@ -980,39 +938,6 @@ const ResearcherRankingChart: React.FC<ResearcherRankingChartProps> = ({
       maximumFractionDigits: 0,
       minimumFractionDigits: 0
     }).format(value);
-  };
-
-  // Obtener valor de Canarias para el año y sector seleccionados
-  const getCanariasValue = (
-    communityData: ResearchersCommunityData[],
-    year: number,
-    sector: string
-  ): number | null => {
-    if (!communityData || communityData.length === 0) return null;
-
-    const sectorMapping: Record<string, string> = {
-      total: '_T',
-      business: 'EMPRESAS',
-      government: 'ADMINISTRACION_PUBLICA',
-      education: 'ENSENIANZA_SUPERIOR',
-      nonprofit: 'IPSFL'
-    };
-
-    const sectorCode = sectorMapping[sector.toLowerCase()] || '_T';
-
-    const record = communityData.find(item =>
-      item.TERRITORIO_CODE === 'ES70' &&
-      parseInt(item.TIME_PERIOD) === year &&
-      item.SECTOR_EJECUCION_CODE === sectorCode &&
-      item.SEXO_CODE === 'T'
-    );
-
-    if (record && record.OBS_VALUE) {
-      const value = parseFloat(record.OBS_VALUE.replace(',', '.'));
-      return isNaN(value) ? null : value;
-    }
-
-    return null;
   };
 
   // Obtener el nombre del país a partir del código

--- a/src/components/ResearchersEuropeanMap.tsx
+++ b/src/components/ResearchersEuropeanMap.tsx
@@ -38,19 +38,6 @@ interface ResearchersData {
   [key: string]: string | undefined;
 }
 
-// Interfaz para los datos de comunidades autónomas
-interface ResearchersCommunityData {
-  TERRITORIO: string;
-  TERRITORIO_CODE: string;
-  TIME_PERIOD: string;
-  SECTOR_EJECUCION: string;
-  SECTOR_EJECUCION_CODE: string;
-  SEXO: string;
-  SEXO_CODE: string;
-  OBS_VALUE: string;
-  [key: string]: string;
-}
-
 // Definición de tipos más estrictos para propiedades
 type GeoJsonProperties = {
   NAME?: string;
@@ -76,7 +63,6 @@ interface ResearchersEuropeanMapProps {
   selectedSector: string;
   language: 'es' | 'en';
   onClick?: (country: string) => void;
-  autonomousCommunitiesData?: ResearchersCommunityData[];
 }
 
 // URL del archivo GeoJSON de Europa
@@ -336,39 +322,6 @@ function getSpainValue(data: ResearchersData[], year: number, sector: string): n
   // Usar el primer resultado que coincida
   if (spainData.length > 0 && spainData[0].OBS_VALUE) {
     return parseFloat(spainData[0].OBS_VALUE);
-  }
-
-  return null;
-}
-
-// Función para obtener el valor de Canarias
-function getCanariasValue(
-  communityData: ResearchersCommunityData[],
-  year: number,
-  sector: string
-): number | null {
-  if (!communityData || communityData.length === 0) return null;
-
-  const sectorMapping: Record<string, string> = {
-    total: '_T',
-    business: 'EMPRESAS',
-    government: 'ADMINISTRACION_PUBLICA',
-    education: 'ENSENIANZA_SUPERIOR',
-    nonprofit: 'IPSFL'
-  };
-
-  const sectorCode = sectorMapping[sector.toLowerCase()] || '_T';
-
-  const record = communityData.find(item =>
-    item.TERRITORIO_CODE === 'ES70' &&
-    parseInt(item.TIME_PERIOD) === year &&
-    item.SECTOR_EJECUCION_CODE === sectorCode &&
-    item.SEXO_CODE === 'T'
-  );
-
-  if (record && record.OBS_VALUE) {
-    const value = parseFloat(record.OBS_VALUE.replace(',', '.'));
-    return isNaN(value) ? null : value;
   }
 
   return null;
@@ -913,8 +866,7 @@ const ResearchersEuropeanMap: React.FC<ResearchersEuropeanMapProps> = ({
   selectedYear,
   selectedSector,
   language,
-  onClick,
-  autonomousCommunitiesData = []
+  onClick
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const [europeanMapData, setEuropeanMapData] = useState<GeoJsonData | null>(null);
@@ -1592,13 +1544,10 @@ const ResearchersEuropeanMap: React.FC<ResearchersEuropeanMapProps> = ({
         // Verificar si es España o la UE para la visualización del tooltip
         const isSpain = countryIso2 === 'ES' || countryIso3 === 'ESP';
         const isEU = countryIso2 === 'EU' || countryData?.geo === 'EU27_2020';
-        const isCanarias = normalizarTexto(countryName).includes('canarias') || normalizarTexto(countryName).includes('canary islands');
-
         // Obtener valores para comparativas
         const euValue = !isEU ? getEUValue(data, selectedYear, selectedSector) : null;
         const euAverageValue = euValue !== null ? Math.round(euValue / 27) : null;
         const spainValue = !isSpain ? getSpainValue(data, selectedYear, selectedSector) : null;
-        const canariasValue = !isCanarias ? getCanariasValue(autonomousCommunitiesData, selectedYear, selectedSector) : null;
         
         // Obtener el valor del año anterior para la comparación YoY - mejorar búsqueda
         let previousYearValue = null;
@@ -1702,31 +1651,6 @@ const ResearchersEuropeanMap: React.FC<ResearchersEuropeanMapProps> = ({
             `;
           }
 
-          // Comparación con Canarias
-          if (!isCanarias) {
-            if (canariasValue !== null) {
-              const difference = value - canariasValue;
-              const percentDiff = (difference / canariasValue) * 100;
-              const formattedDiff = percentDiff.toFixed(1);
-              const isPositive = difference > 0;
-
-              comparisonsHtml += `
-                <div class="flex justify-between items-center text-xs">
-                  <span class="text-gray-600 inline-block w-44">${language === 'es' ?
-                    `vs Islas Canarias (${formatNumberComplete(Math.round(canariasValue), 0, language)}):` :
-                    `vs Canary Islands (${formatNumberComplete(Math.round(canariasValue), 0, language)}):`}</span>
-                  <span class="font-medium ${isPositive ? 'text-green-600' : 'text-red-600'}">${isPositive ? '+' : ''}${formattedDiff}%</span>
-                </div>
-              `;
-            } else {
-              comparisonsHtml += `
-                <div class="flex justify-between items-center text-xs">
-                  <span class="text-gray-600 inline-block w-44">${language === 'es' ? 'vs Islas Canarias:' : 'vs Canary Islands:'}</span>
-                  <span class="font-medium text-gray-400">--</span>
-                </div>
-              `;
-            }
-          }
         }
 
         let tooltipContent = '';
@@ -1892,7 +1816,7 @@ const ResearchersEuropeanMap: React.FC<ResearchersEuropeanMapProps> = ({
     };
 
     renderMap();
-  }, [europeanMapData, data, selectedYear, selectedSector, language, autonomousCommunitiesData]);
+  }, [europeanMapData, data, selectedYear, selectedSector, language]);
   
   return (
     <div ref={containerRef} className="relative w-full h-full overflow-hidden">

--- a/src/pages/Researchers/index.tsx
+++ b/src/pages/Researchers/index.tsx
@@ -499,7 +499,6 @@ const Researchers: React.FC<ResearchersProps> = (props) => {
                       selectedYear={selectedYear}
                       selectedSector={mapSectorToCode(mapSector)}
                       language={language}
-                      autonomousCommunitiesData={researchersCommunityData}
                     />
                   </div>
                 </div>
@@ -511,7 +510,6 @@ const Researchers: React.FC<ResearchersProps> = (props) => {
                     selectedYear={selectedYear}
                     language={language}
                     selectedSector={mapSectorToCode(mapSector)}
-                    autonomousCommunitiesData={researchersCommunityData}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- remove Canary Islands comparison from country-level researcher map tooltips
- remove Canary Islands comparison from researcher country ranking tooltips
- drop unused props and data related to Canary Islands comparisons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in src/utils/dataUtils.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a61db2a47883289c0c044b66ec7b48